### PR TITLE
Add missing requirement (ext-intl) to composer.json

### DIFF
--- a/uri/composer.json
+++ b/uri/composer.json
@@ -45,6 +45,7 @@
     ],
     "require": {
         "php": "^8.1",
+        "ext-intl": "*",
         "ext-json": "*",
         "psr/http-message": "^1.0.1",
         "league/uri-interfaces": "^2.3"


### PR DESCRIPTION
```
vendor/league/uri/src/Uri.php
61:use const IDNA_ERROR_EMPTY_LABEL;
174:        IDNA_ERROR_EMPTY_LABEL => 'a non-final domain name label (or the whole domain name) is empty',

vendor/league/uri/src/UriString.php
41:use const IDNA_ERROR_EMPTY_LABEL;
483:            IDNA_ERROR_EMPTY_LABEL => 'a non-final domain name label (or the whole domain name) is empty',
>…
```

This package use some constant from [intl](https://www.php.net/manual/en/intl.constants.php)