### PR TITLE
Fix broken code that assumes array keys are strings

### DIFF
--- a/uri/UriTemplate/Expression.php
+++ b/uri/UriTemplate/Expression.php
@@ -37,10 +37,12 @@ final class Expression
     private function __construct(public readonly Operator $operator, VarSpecifier ...$varSpecifiers)
     {
         $this->varSpecifiers = $varSpecifiers;
-        $this->variableNames = array_keys(array_fill_keys(
-            array_map(static fn (VarSpecifier $varSpecifier): string => $varSpecifier->name, $varSpecifiers),
-            1
-        ));
+        $this->variableNames = array_unique(
+            array_map(
+                static fn (VarSpecifier $varSpecifier): string => $varSpecifier->name,
+                $varSpecifiers
+            )
+        );
         $this->value = '{'.$operator->value.implode(',', array_map(
             static fn (VarSpecifier $varSpecifier): string => $varSpecifier->toString(),
             $varSpecifiers

--- a/uri/UriTemplate/Template.php
+++ b/uri/UriTemplate/Template.php
@@ -43,14 +43,14 @@ final class Template implements Stringable
     private function __construct(public readonly string $value, Expression ...$expressions)
     {
         $this->expressions = $expressions;
-        $this->variableNames = array_keys(array_reduce(
-            $expressions,
-            fn (array $curry, Expression $expression): array => [
-                ...$curry,
-                ...array_fill_keys($expression->variableNames, 1),
-            ],
-            []
-        ));
+        $this->variableNames = array_unique(
+            array_merge(
+                ...array_map(
+                    fn (Expression $expression): array => $expression->variableNames,
+                    $expressions
+                )
+            )
+        );
     }
 
     /**

--- a/uri/UriTemplate/Template.php
+++ b/uri/UriTemplate/Template.php
@@ -46,7 +46,7 @@ final class Template implements Stringable
         $this->variableNames = array_unique(
             array_merge(
                 ...array_map(
-                    fn (Expression $expression): array => $expression->variableNames,
+                    static fn (Expression $expression): array => $expression->variableNames,
                     $expressions
                 )
             )

--- a/uri/UriTemplate/TemplateTest.php
+++ b/uri/UriTemplate/TemplateTest.php
@@ -144,8 +144,8 @@ final class TemplateTest extends TestCase
                 'expected' => [],
             ],
             [
-                'template' => '{foo}{bar}',
-                'expected' => ['foo', 'bar'],
+                'template' => '{foo}{bar}{420}',
+                'expected' => ['foo', 'bar', '420'],
             ],
             [
                 'template' => '{foo}{foo:2}{+foo}',


### PR DESCRIPTION
I know that array_merge and array_unique have bad complexity, however typically templates have low numbers of variables, like sub-100, so I don't think this will be an issue, and may actually be faster than the array_reduce with small numbers of variables.

---

Closes #119.