### PR TITLE
Bugfix/query parameters constructors encoding values

### DIFF
--- a/components/CHANGELOG.md
+++ b/components/CHANGELOG.md
@@ -6,7 +6,8 @@ All Notable changes to `League\Uri\Components` will be documented in this file
 
 ### Added
 
-- None
+- `Query::fromPhpVariable`
+- `UrlSearchParams::fromPhpVariable`
 
 ### Fixed
 
@@ -14,7 +15,8 @@ All Notable changes to `League\Uri\Components` will be documented in this file
 
 ### Deprecated
 
-- None
+- `Query::fromParameters` use `Query::fromPhpVariable` instead
+- `UrlSearchParams::fromParameters` use `UrlSearchParams::fromPhpVariable` instead
 
 ### Removed
 

--- a/components/CHANGELOG.md
+++ b/components/CHANGELOG.md
@@ -6,8 +6,8 @@ All Notable changes to `League\Uri\Components` will be documented in this file
 
 ### Added
 
-- `Query::fromPhpVariable`
-- `UrlSearchParams::fromPhpVariable`
+- `Query::fromVariable`
+- `UrlSearchParams::fromVariable`
 
 ### Fixed
 
@@ -15,8 +15,8 @@ All Notable changes to `League\Uri\Components` will be documented in this file
 
 ### Deprecated
 
-- `Query::fromParameters` use `Query::fromPhpVariable` instead
-- `UrlSearchParams::fromParameters` use `UrlSearchParams::fromPhpVariable` instead
+- `Query::fromParameters` use `Query::fromVariable` instead
+- `UrlSearchParams::fromParameters` use `UrlSearchParams::fromVariable` instead
 
 ### Removed
 

--- a/components/Components/Query.php
+++ b/components/Components/Query.php
@@ -22,7 +22,6 @@ use League\Uri\KeyValuePair\Converter;
 use League\Uri\QueryString;
 use Psr\Http\Message\UriInterface as Psr7UriInterface;
 use Stringable;
-use Traversable;
 
 use function array_column;
 use function array_count_values;
@@ -35,7 +34,6 @@ use function count;
 use function http_build_query;
 use function implode;
 use function is_int;
-use function iterator_to_array;
 use function preg_match;
 use function preg_quote;
 use function preg_replace;
@@ -69,27 +67,13 @@ final class Query extends Component implements QueryInterface
     }
 
     /**
-     * Returns a new instance from the result of PHP's parse_str.
+     * Returns a new instance from the input of http_build_query.
      *
      * @param non-empty-string $separator
      */
     public static function fromParameters(object|array $parameters, string $separator = '&'): self
     {
-        if ($parameters instanceof QueryInterface || $parameters instanceof URLSearchParams) {
-            return self::fromPairs($parameters, $separator);
-        }
-
-        $parameters = match (true) {
-            $parameters instanceof Traversable => iterator_to_array($parameters),
-            default => $parameters,
-        };
-
-        $query = match ([]) {
-            $parameters => null,
-            default => http_build_query(data: $parameters, arg_separator: $separator),
-        };
-
-        return new self($query, Converter::fromRFC1738($separator));
+        return new self(http_build_query(data: $parameters, arg_separator: $separator), Converter::fromRFC1738($separator));
     }
 
     /**

--- a/components/Components/Query.php
+++ b/components/Components/Query.php
@@ -75,7 +75,7 @@ final class Query extends Component implements QueryInterface
      */
     public static function fromParameters(object|array $parameters, string $separator = '&'): self
     {
-        if ($parameters instanceof QueryInterface) {
+        if ($parameters instanceof QueryInterface || $parameters instanceof URLSearchParams) {
             return self::fromPairs($parameters, $separator);
         }
 

--- a/components/Components/Query.php
+++ b/components/Components/Query.php
@@ -73,7 +73,7 @@ final class Query extends Component implements QueryInterface
      *
      * @param non-empty-string $separator
      */
-    public static function fromPhpVariable(object|array $parameters, string $separator = '&'): self
+    public static function fromVariable(object|array $parameters, string $separator = '&'): self
     {
         return new self(http_build_query(data: $parameters, arg_separator: $separator), Converter::fromRFC1738($separator));
     }
@@ -660,7 +660,7 @@ final class Query extends Component implements QueryInterface
      *
      * @param non-empty-string $separator
      *
-     * @see Query::fromPhpVariable()
+     * @see Query::fromVariable()
      *
      * @codeCoverageIgnore
      * Returns a new instance from the result of PHP's parse_str.

--- a/components/Components/QueryTest.php
+++ b/components/Components/QueryTest.php
@@ -349,7 +349,7 @@ final class QueryTest extends TestCase
      */
     public function testwithoutParam(array $origin, array $without, string $expected): void
     {
-        self::assertSame($expected, Query::fromParameters($origin)->withoutParameters(...$without)->toString());
+        self::assertSame($expected, Query::fromPhpVariable($origin)->withoutParameters(...$without)->toString());
     }
 
     public static function withoutParamProvider(): array
@@ -408,7 +408,7 @@ final class QueryTest extends TestCase
             ],
         ];
 
-        $query = Query::fromParameters($data);
+        $query = Query::fromPhpVariable($data);
         self::assertSame('foo%5B0%5D=bar&foo%5B1%5D=baz', $query->value());
 
         self::assertTrue($query->hasParameter('foo'));
@@ -437,13 +437,13 @@ final class QueryTest extends TestCase
             ],
         ];
 
-        self::assertSame([], Query::fromParameters(new ArrayIterator($data))->parameters());
+        self::assertSame([], Query::fromPhpVariable(new ArrayIterator($data))->parameters());
     }
 
     public function testCreateFromParamsWithQueryObject(): void
     {
         $query = Query::new('a=1&b=2');
-        self::assertEquals('pairs%5B0%5D%5B0%5D=a&pairs%5B0%5D%5B1%5D=1&pairs%5B1%5D%5B0%5D=b&pairs%5B1%5D%5B1%5D=2&separator=%26&parameters%5Ba%5D=1&parameters%5Bb%5D=2', Query::fromParameters($query)->value());
+        self::assertEquals('pairs%5B0%5D%5B0%5D=a&pairs%5B0%5D%5B1%5D=1&pairs%5B1%5D%5B0%5D=b&pairs%5B1%5D%5B1%5D=2&separator=%26&parameters%5Ba%5D=1&parameters%5Bb%5D=2', Query::fromPhpVariable($query)->value());
     }
 
     public static function testWithoutNumericIndices(): void
@@ -464,7 +464,7 @@ final class QueryTest extends TestCase
         $withIndices = 'filter%5Bfoo%5D%5B0%5D=bar&filter%5Bfoo%5D%5B1%5D=baz&filter%5Bbar%5D%5Bbar%5D=foo&filter%5Bbar%5D%5Bfoo%5D=bar';
         $withoutIndices = 'filter%5Bfoo%5D%5B%5D=bar&filter%5Bfoo%5D%5B%5D=baz&filter%5Bbar%5D%5Bbar%5D=foo&filter%5Bbar%5D%5Bfoo%5D=bar';
 
-        $query = Query::fromParameters($data);
+        $query = Query::fromPhpVariable($data);
         self::assertSame($withIndices, $query->value());
         self::assertSame($data, $query->parameters());
 
@@ -488,43 +488,43 @@ final class QueryTest extends TestCase
 
     public function testWithoutNumericIndicesDoesNotAffectPairValue(): void
     {
-        $query = Query::fromParameters(['foo' => 'bar[3]']);
+        $query = Query::fromPhpVariable(['foo' => 'bar[3]']);
 
         self::assertSame($query, $query->withoutNumericIndices());
     }
 
     public function testCreateFromParamsOnEmptyParams(): void
     {
-        $query = Query::fromParameters([]);
+        $query = Query::fromPhpVariable([]);
 
         self::assertSame($query, $query->withoutNumericIndices());
     }
 
     public function testGetContentOnEmptyContent(): void
     {
-        self::assertSame('', Query::fromParameters([])->value());
+        self::assertSame('', Query::fromPhpVariable([])->value());
     }
 
     public function testGetContentOnHavingContent(): void
     {
-        self::assertSame('foo=bar', Query::fromParameters(['foo' => 'bar'])->value());
+        self::assertSame('foo=bar', Query::fromPhpVariable(['foo' => 'bar'])->value());
     }
 
     public function testGetContentOnToString(): void
     {
-        self::assertSame('foo=bar', (string) Query::fromParameters(['foo' => 'bar']));
+        self::assertSame('foo=bar', (string) Query::fromPhpVariable(['foo' => 'bar']));
     }
 
     public function testWithSeperatorOnHavingSeparator(): void
     {
-        $query = Query::fromParameters(['foo' => '/bar']);
+        $query = Query::fromPhpVariable(['foo' => '/bar']);
 
         self::assertSame($query, $query->withSeparator('&'));
     }
 
     public function testWithoutNumericIndicesOnEmptyContent(): void
     {
-        $query = Query::fromParameters([]);
+        $query = Query::fromPhpVariable([]);
 
         self::assertSame($query, $query->withoutNumericIndices());
     }
@@ -804,7 +804,7 @@ final class QueryTest extends TestCase
     public function testInstantiationFromURLSearchParams(): void
     {
         $expected = ['foo' => 'bar'];
-        $query = Query::fromParameters(URLSearchParams::fromParameters($expected));
+        $query = Query::fromPhpVariable(URLSearchParams::fromPhpVariable($expected));
 
         self::assertSame('', $query->value());
     }

--- a/components/Components/QueryTest.php
+++ b/components/Components/QueryTest.php
@@ -349,7 +349,7 @@ final class QueryTest extends TestCase
      */
     public function testwithoutParam(array $origin, array $without, string $expected): void
     {
-        self::assertSame($expected, Query::fromPhpVariable($origin)->withoutParameters(...$without)->toString());
+        self::assertSame($expected, Query::fromVariable($origin)->withoutParameters(...$without)->toString());
     }
 
     public static function withoutParamProvider(): array
@@ -408,7 +408,7 @@ final class QueryTest extends TestCase
             ],
         ];
 
-        $query = Query::fromPhpVariable($data);
+        $query = Query::fromVariable($data);
         self::assertSame('foo%5B0%5D=bar&foo%5B1%5D=baz', $query->value());
 
         self::assertTrue($query->hasParameter('foo'));
@@ -437,13 +437,13 @@ final class QueryTest extends TestCase
             ],
         ];
 
-        self::assertSame([], Query::fromPhpVariable(new ArrayIterator($data))->parameters());
+        self::assertSame([], Query::fromVariable(new ArrayIterator($data))->parameters());
     }
 
     public function testCreateFromParamsWithQueryObject(): void
     {
         $query = Query::new('a=1&b=2');
-        self::assertEquals('pairs%5B0%5D%5B0%5D=a&pairs%5B0%5D%5B1%5D=1&pairs%5B1%5D%5B0%5D=b&pairs%5B1%5D%5B1%5D=2&separator=%26&parameters%5Ba%5D=1&parameters%5Bb%5D=2', Query::fromPhpVariable($query)->value());
+        self::assertEquals('pairs%5B0%5D%5B0%5D=a&pairs%5B0%5D%5B1%5D=1&pairs%5B1%5D%5B0%5D=b&pairs%5B1%5D%5B1%5D=2&separator=%26&parameters%5Ba%5D=1&parameters%5Bb%5D=2', Query::fromVariable($query)->value());
     }
 
     public static function testWithoutNumericIndices(): void
@@ -464,7 +464,7 @@ final class QueryTest extends TestCase
         $withIndices = 'filter%5Bfoo%5D%5B0%5D=bar&filter%5Bfoo%5D%5B1%5D=baz&filter%5Bbar%5D%5Bbar%5D=foo&filter%5Bbar%5D%5Bfoo%5D=bar';
         $withoutIndices = 'filter%5Bfoo%5D%5B%5D=bar&filter%5Bfoo%5D%5B%5D=baz&filter%5Bbar%5D%5Bbar%5D=foo&filter%5Bbar%5D%5Bfoo%5D=bar';
 
-        $query = Query::fromPhpVariable($data);
+        $query = Query::fromVariable($data);
         self::assertSame($withIndices, $query->value());
         self::assertSame($data, $query->parameters());
 
@@ -488,43 +488,43 @@ final class QueryTest extends TestCase
 
     public function testWithoutNumericIndicesDoesNotAffectPairValue(): void
     {
-        $query = Query::fromPhpVariable(['foo' => 'bar[3]']);
+        $query = Query::fromVariable(['foo' => 'bar[3]']);
 
         self::assertSame($query, $query->withoutNumericIndices());
     }
 
     public function testCreateFromParamsOnEmptyParams(): void
     {
-        $query = Query::fromPhpVariable([]);
+        $query = Query::fromVariable([]);
 
         self::assertSame($query, $query->withoutNumericIndices());
     }
 
     public function testGetContentOnEmptyContent(): void
     {
-        self::assertSame('', Query::fromPhpVariable([])->value());
+        self::assertSame('', Query::fromVariable([])->value());
     }
 
     public function testGetContentOnHavingContent(): void
     {
-        self::assertSame('foo=bar', Query::fromPhpVariable(['foo' => 'bar'])->value());
+        self::assertSame('foo=bar', Query::fromVariable(['foo' => 'bar'])->value());
     }
 
     public function testGetContentOnToString(): void
     {
-        self::assertSame('foo=bar', (string) Query::fromPhpVariable(['foo' => 'bar']));
+        self::assertSame('foo=bar', (string) Query::fromVariable(['foo' => 'bar']));
     }
 
     public function testWithSeperatorOnHavingSeparator(): void
     {
-        $query = Query::fromPhpVariable(['foo' => '/bar']);
+        $query = Query::fromVariable(['foo' => '/bar']);
 
         self::assertSame($query, $query->withSeparator('&'));
     }
 
     public function testWithoutNumericIndicesOnEmptyContent(): void
     {
-        $query = Query::fromPhpVariable([]);
+        $query = Query::fromVariable([]);
 
         self::assertSame($query, $query->withoutNumericIndices());
     }
@@ -804,7 +804,7 @@ final class QueryTest extends TestCase
     public function testInstantiationFromURLSearchParams(): void
     {
         $expected = ['foo' => 'bar'];
-        $query = Query::fromPhpVariable(URLSearchParams::fromPhpVariable($expected));
+        $query = Query::fromVariable(URLSearchParams::fromVariable($expected));
 
         self::assertSame('', $query->value());
     }

--- a/components/Components/QueryTest.php
+++ b/components/Components/QueryTest.php
@@ -437,13 +437,13 @@ final class QueryTest extends TestCase
             ],
         ];
 
-        self::assertSame($data, Query::fromParameters(new ArrayIterator($data))->parameters());
+        self::assertSame([], Query::fromParameters(new ArrayIterator($data))->parameters());
     }
 
     public function testCreateFromParamsWithQueryObject(): void
     {
         $query = Query::new('a=1&b=2');
-        self::assertEquals($query->value(), Query::fromParameters($query)->value());
+        self::assertEquals('pairs%5B0%5D%5B0%5D=a&pairs%5B0%5D%5B1%5D=1&pairs%5B1%5D%5B0%5D=b&pairs%5B1%5D%5B1%5D=2&separator=%26&parameters%5Ba%5D=1&parameters%5Bb%5D=2', Query::fromParameters($query)->value());
     }
 
     public static function testWithoutNumericIndices(): void
@@ -502,7 +502,7 @@ final class QueryTest extends TestCase
 
     public function testGetContentOnEmptyContent(): void
     {
-        self::assertNull(Query::fromParameters([])->value());
+        self::assertSame('', Query::fromParameters([])->value());
     }
 
     public function testGetContentOnHavingContent(): void
@@ -806,6 +806,6 @@ final class QueryTest extends TestCase
         $expected = ['foo' => 'bar'];
         $query = Query::fromParameters(URLSearchParams::fromParameters($expected));
 
-        self::assertSame($expected, $query->parameters());
+        self::assertSame('', $query->value());
     }
 }

--- a/components/Components/QueryTest.php
+++ b/components/Components/QueryTest.php
@@ -800,4 +800,12 @@ final class QueryTest extends TestCase
 
         Query::fromRFC1738('foo=b%20ar;foo=baz', ''); /* @phpstan-ignore-line */
     }
+
+    public function testInstantiationFromURLSearchParams(): void
+    {
+        $expected = ['foo' => 'bar'];
+        $query = Query::fromParameters(URLSearchParams::fromParameters($expected));
+
+        self::assertSame($expected, $query->parameters());
+    }
 }

--- a/components/Components/URLSearchParams.php
+++ b/components/Components/URLSearchParams.php
@@ -213,7 +213,7 @@ final class URLSearchParams implements Countable, IteratorAggregate, UriComponen
     /**
      * Returns a new instance from the input of PHP's http_build_query.
      */
-    public static function fromPhpVariable(object|array $parameters): self
+    public static function fromVariable(object|array $parameters): self
     {
         return self::fromPairs(self::parametersToPairs($parameters));
     }
@@ -486,7 +486,7 @@ final class URLSearchParams implements Countable, IteratorAggregate, UriComponen
      * DEPRECATION WARNING! This method will be removed in the next major point release.
      *
      * @deprecated Since version 7.4.0
-     * @see URLSearchParams::fromPhpVariable()
+     * @see URLSearchParams::fromVariable()
      *
      * @codeCoverageIgnore
      *

--- a/components/Components/URLSearchParams.php
+++ b/components/Components/URLSearchParams.php
@@ -213,7 +213,7 @@ final class URLSearchParams implements Countable, IteratorAggregate, UriComponen
     /**
      * Returns a new instance from the input of PHP's http_build_query.
      */
-    public static function fromParameters(object|array $parameters): self
+    public static function fromPhpVariable(object|array $parameters): self
     {
         return self::fromPairs(self::parametersToPairs($parameters));
     }
@@ -480,5 +480,19 @@ final class URLSearchParams implements Countable, IteratorAggregate, UriComponen
     public function sort(): void
     {
         $this->updateQuery($this->pairs->sort());
+    }
+
+    /**
+     * DEPRECATION WARNING! This method will be removed in the next major point release.
+     *
+     * @deprecated Since version 7.4.0
+     * @see URLSearchParams::fromPhpVariable()
+     *
+     * @codeCoverageIgnore
+     *
+     */
+    public static function fromParameters(object|array $parameters): self
+    {
+        return new self(Query::fromParameters($parameters));
     }
 }

--- a/components/Components/URLSearchParamsTest.php
+++ b/components/Components/URLSearchParamsTest.php
@@ -818,6 +818,8 @@ JSON;
     }
 
     /**
+     * @see https://github.com/php/php-src/tree/master/ext/standard/tests/http/http_build_query
+     *
      * @dataProvider providesParametersInput
      */
     public function testFromParametersWithDifferentInput(object|array $data, string $expected): void
@@ -977,7 +979,7 @@ JSON;
                     yield from ['foo' => 'bar'];
                 }
             },
-            'expected' => 'foo=bar',
+            'expected' => '',
         ];
     }
 }

--- a/components/Components/URLSearchParamsTest.php
+++ b/components/Components/URLSearchParamsTest.php
@@ -742,7 +742,7 @@ JSON;
             ],
         ];
 
-        $params = URLSearchParams::fromPhpVariable($parameters);
+        $params = URLSearchParams::fromVariable($parameters);
         self::assertCount(4, $params);
         self::assertSame('bar baz', $params->get('filter[foo][0]'));
         self::assertSame('bar', $params->get('filter[bar][foo]'));
@@ -813,7 +813,7 @@ JSON;
 
         self::assertSame(
             URLSearchParams::fromAssociative($parameters)->toString(),
-            URLSearchParams::fromPhpVariable($parameters)->toString(),
+            URLSearchParams::fromVariable($parameters)->toString(),
         );
     }
 
@@ -824,7 +824,7 @@ JSON;
      */
     public function testFromParametersWithDifferentInput(object|array $data, string $expected): void
     {
-        self::assertSame($expected, URLSearchParams::fromPhpVariable($data)->toString());
+        self::assertSame($expected, URLSearchParams::fromVariable($data)->toString());
     }
 
     public static function providesParametersInput(): iterable

--- a/components/Components/URLSearchParamsTest.php
+++ b/components/Components/URLSearchParamsTest.php
@@ -742,7 +742,7 @@ JSON;
             ],
         ];
 
-        $params = URLSearchParams::fromParameters($parameters);
+        $params = URLSearchParams::fromPhpVariable($parameters);
         self::assertCount(4, $params);
         self::assertSame('bar baz', $params->get('filter[foo][0]'));
         self::assertSame('bar', $params->get('filter[bar][foo]'));
@@ -813,7 +813,7 @@ JSON;
 
         self::assertSame(
             URLSearchParams::fromAssociative($parameters)->toString(),
-            URLSearchParams::fromParameters($parameters)->toString(),
+            URLSearchParams::fromPhpVariable($parameters)->toString(),
         );
     }
 
@@ -824,7 +824,7 @@ JSON;
      */
     public function testFromParametersWithDifferentInput(object|array $data, string $expected): void
     {
-        self::assertSame($expected, URLSearchParams::fromParameters($data)->toString());
+        self::assertSame($expected, URLSearchParams::fromPhpVariable($data)->toString());
     }
 
     public static function providesParametersInput(): iterable

--- a/components/Components/URLSearchParamsTest.php
+++ b/components/Components/URLSearchParamsTest.php
@@ -19,6 +19,7 @@ use IteratorAggregate;
 use League\Uri\Exceptions\SyntaxError;
 use PHPUnit\Framework\TestCase;
 use stdClass;
+use Stringable;
 use Traversable;
 
 final class URLSearchParamsTest extends TestCase
@@ -804,5 +805,179 @@ JSON;
         self::assertSame('b', $params->get('a'));
 
         self::assertSame('b', URLSearchParams::new('%3Fa=b')->get('?a'));
+    }
+
+    public function testFromParametersRespectURLSpecTypeConversion(): void
+    {
+        $parameters = new DateInterval('P12MT23H12S');
+
+        self::assertSame(
+            URLSearchParams::fromAssociative($parameters)->toString(),
+            URLSearchParams::fromParameters($parameters)->toString(),
+        );
+    }
+
+    /**
+     * @dataProvider providesParametersInput
+     */
+    public function testFromParametersWithDifferentInput(object|array $data, string $expected): void
+    {
+        self::assertSame($expected, URLSearchParams::fromParameters($data)->toString());
+    }
+
+    public static function providesParametersInput(): iterable
+    {
+        yield 'from an object with public properties' => [
+            'data' => ['foo' => 'bar', 'baz' => 1, 'test' => "a ' \" ", 'abc', 'float' => 10.42, 'true' => true, 'false' => false],
+            'expected' => 'foo=bar&baz=1&test=a+%27+%22+&0=abc&float=10.42&true=true&false=false',
+        ];
+
+        yield 'empty parameters' => [
+            'data' => [],
+            'expected' => '',
+        ];
+
+        yield 'encoding of the plus sign and the float number' => [
+            'data' => ['x' => 1E+14, 'y' => '1E+14'],
+            'expected' => 'x=100000000000000.0&y=1E%2B14',
+        ];
+
+        yield 'class public properties' => [
+          'data' => new class () {
+              public string $public = 'input';
+              protected string $protected = 'hello';
+              private string $private = 'world'; /* @phpstan-ignore-line */
+          },
+          'expected' => 'public=input',
+        ];
+
+        yield 'empty class' => [
+            'data' => new class () {},
+            'expected' => '',
+        ];
+
+        yield 'just stringable class' => [
+            'data' => new class () implements Stringable {
+                public function __toString(): string
+                {
+                    return $this::class;
+                }
+            },
+            'expected' => '',
+        ];
+
+        yield 'stringable object' => [
+            'data' => ['hello', new class () implements Stringable {
+                public function __toString(): string
+                {
+                    return $this::class;
+                }
+            }],
+            'expected' => '0=hello',
+        ];
+
+        yield 'stringable class with public properties' => [
+            'data' => new class () implements Stringable {
+                public string $public = 'input';
+                protected string $protected = 'hello';
+                private string $private = 'world'; /* @phpstan-ignore-line */
+                public function __toString(): string
+                {
+                    return $this::class;
+                }
+            },
+            'expected' => 'public=input',
+        ];
+
+        $parent = new class () {
+            public mixed $public = 'input';
+            protected string $protected = 'hello';
+            private string $private = 'world'; /* @phpstan-ignore-line */
+        };
+
+        $child = new class () {
+            public mixed $public = 'input';
+            protected string $protected = 'hello';
+            private string $private = 'world'; /* @phpstan-ignore-line */
+        };
+
+        $parent->public = $child;
+
+        yield 'nested classes' => [
+            'data' => $parent,
+            'expected' => 'public%5Bpublic%5D=input',
+        ];
+
+        yield 'nested arrays' => [
+            'data' => [
+                20,
+                5 => 13,
+                '9' => [
+                    1 => 'val1',
+                    3 => 'val2',
+                    'string' => 'string',
+                ],
+                'name' => 'homepage',
+                'page' => 10,
+                'sort' => [
+                    'desc',
+                    'admin' => [
+                        'admin1',
+                        'admin2' => [
+                            'who' => 'admin2',
+                            2 => 'test',
+                        ],
+                    ],
+                ],
+            ],
+            'expected' => '0=20&5=13&9%5B1%5D=val1&9%5B3%5D=val2&9%5Bstring%5D=string&name=homepage&page=10&sort%5B0%5D=desc&sort%5Badmin%5D%5B0%5D=admin1&sort%5Badmin%5D%5Badmin2%5D%5Bwho%5D=admin2&sort%5Badmin%5D%5Badmin2%5D%5B2%5D=test',
+        ];
+
+        yield 'test with mathematical expression' => [
+            'data' => [
+                'name' => 'main page',
+                'sort' => 'desc,admin',
+                'equation' => '10 + 10 - 5',
+            ],
+            'expected' => 'name=main+page&sort=desc%2Cadmin&equation=10+%2B+10+-+5',
+        ];
+
+        yield 'test with array containing null value' => [
+            'data' => [null],
+            'expected' => '',
+        ];
+
+        yield 'test with resource' => [
+            'data' => [STDIN],
+            'expected' => '',
+        ];
+
+        $recursive = new class () {
+            public mixed $public = 'input';
+        };
+        $recursive->public = $recursive;
+
+        yield 'test object recursion' => [
+            'data' => $recursive,
+            'expected' => '',
+        ];
+
+        $v = 'value';
+        $ref = &$v;
+
+        yield 'using reference in array' => [
+            'data' => [$ref],
+            'expected' => '0=value',
+        ];
+
+        yield 'using a traversable' => [
+            'data' => new class () implements IteratorAggregate {
+                public function getIterator(): Traversable
+                {
+                    yield from ['foo' => 'bar'];
+                }
+            },
+            'expected' => 'foo=bar',
+        ];
     }
 }

--- a/components/Modifier.php
+++ b/components/Modifier.php
@@ -150,7 +150,7 @@ class Modifier implements Stringable, JsonSerializable, UriAccess
      */
     public function appendQueryParameters(object|array $parameters): self
     {
-        return $this->appendQuery(Query::fromPhpVariable($parameters)->value());
+        return $this->appendQuery(Query::fromVariable($parameters)->value());
     }
 
     /**
@@ -200,7 +200,7 @@ class Modifier implements Stringable, JsonSerializable, UriAccess
             $currentParameters === $parameters => $this,
             default => new static($this->uri->withQuery(
                 self::normalizeComponent(
-                    Query::fromPhpVariable([...$currentParameters, ...$parameters])->value(),
+                    Query::fromVariable([...$currentParameters, ...$parameters])->value(),
                     $this->uri
                 )
             )),

--- a/components/Modifier.php
+++ b/components/Modifier.php
@@ -30,8 +30,8 @@ use League\Uri\KeyValuePair\Converter as KeyValuePairConverter;
 use Psr\Http\Message\UriFactoryInterface;
 use Psr\Http\Message\UriInterface as Psr7UriInterface;
 use Stringable;
-use Traversable;
 
+use function get_object_vars;
 use function ltrim;
 use function rtrim;
 use function str_ends_with;
@@ -150,7 +150,7 @@ class Modifier implements Stringable, JsonSerializable, UriAccess
      */
     public function appendQueryParameters(object|array $parameters): self
     {
-        return $this->appendQuery(Query::fromParameters($parameters)->value());
+        return $this->appendQuery(Query::fromPhpVariable($parameters)->value());
     }
 
     /**
@@ -186,10 +186,10 @@ class Modifier implements Stringable, JsonSerializable, UriAccess
     /**
      *  Merge PHP query parameters with the existing URI query.
      */
-    public function mergeQueryParameters(iterable $parameters): self
+    public function mergeQueryParameters(object|array $parameters): self
     {
         $parameters = match (true) {
-            $parameters instanceof Traversable => iterator_to_array($parameters),
+            is_object($parameters) => get_object_vars($parameters),
             default => $parameters,
         };
 
@@ -200,7 +200,7 @@ class Modifier implements Stringable, JsonSerializable, UriAccess
             $currentParameters === $parameters => $this,
             default => new static($this->uri->withQuery(
                 self::normalizeComponent(
-                    Query::fromParameters([...$currentParameters, ...$parameters])->value(),
+                    Query::fromPhpVariable([...$currentParameters, ...$parameters])->value(),
                     $this->uri
                 )
             )),

--- a/docs/components/7.0/query.md
+++ b/docs/components/7.0/query.md
@@ -174,12 +174,16 @@ $newQuery->__toString(); //return baz=toto&foo=bar&foo=toto
 ## Using the Query as a PHP data transport layer
 
 ~~~php
-public static Query::fromParameters($params, string $separator = '&'): self
+public static Query::fromPhpVariable($params, string $separator = '&'): self
 public Query::parameters(): array
 public Query::parameter(string $name): mixed
 public Query::withoutNumericIndices(): self
 public Query::withoutParameter(...string $offsets): self
 ~~~
+
+<p class="message-info"><code>Query::fromPhpVariable</code> replaced the deprecated 
+<code>Query::fromParameters</code> named constructor which was 
+not inconsistent against <code>http_build_query</code> algorithm.</p>
 
 ### Using PHP data structure to instantiate a new Query object
 
@@ -189,7 +193,7 @@ PHP own data structure to generate a query string *à la* `http_build_query`.
 ~~~php
 parse_str('foo=bar&bar=baz+bar', $params);
 
-$query = Query::fromParameters($params, '|');
+$query = Query::fromPhpVariable($params, '|');
 echo $query->value(); // returns 'foo=bar|bar=baz%20bar'
 ~~~
 
@@ -244,7 +248,7 @@ If your query string is created with `http_build_query` or the `Query::fromParam
 The `Query::withoutNumericIndices` removes any numeric index found in the query string as shown below:
 
 ~~~php
-$query = Query::fromParameters(['foo' => ['bar', 'baz']]);
+$query = Query::fromPhpVariable(['foo' => ['bar', 'baz']]);
 echo $query->value(); //return 'foo[0]=bar&foo[1]=baz'
 $new_query = $query->withoutNumericIndices();
 echo $new_query->value(); //return 'foo[]=bar&foo[]=baz'

--- a/docs/components/7.0/query.md
+++ b/docs/components/7.0/query.md
@@ -174,14 +174,14 @@ $newQuery->__toString(); //return baz=toto&foo=bar&foo=toto
 ## Using the Query as a PHP data transport layer
 
 ~~~php
-public static Query::fromPhpVariable($params, string $separator = '&'): self
+public static Query::fromVariable($params, string $separator = '&'): self
 public Query::parameters(): array
 public Query::parameter(string $name): mixed
 public Query::withoutNumericIndices(): self
 public Query::withoutParameter(...string $offsets): self
 ~~~
 
-<p class="message-info"><code>Query::fromPhpVariable</code> replaced the deprecated 
+<p class="message-info"><code>Query::fromVariable</code> replaced the deprecated 
 <code>Query::fromParameters</code> named constructor which was 
 not inconsistent against <code>http_build_query</code> algorithm.</p>
 
@@ -193,7 +193,7 @@ PHP own data structure to generate a query string *à la* `http_build_query`.
 ~~~php
 parse_str('foo=bar&bar=baz+bar', $params);
 
-$query = Query::fromPhpVariable($params, '|');
+$query = Query::fromVariable($params, '|');
 echo $query->value(); // returns 'foo=bar|bar=baz%20bar'
 ~~~
 
@@ -248,7 +248,7 @@ If your query string is created with `http_build_query` or the `Query::fromParam
 The `Query::withoutNumericIndices` removes any numeric index found in the query string as shown below:
 
 ~~~php
-$query = Query::fromPhpVariable(['foo' => ['bar', 'baz']]);
+$query = Query::fromVariable(['foo' => ['bar', 'baz']]);
 echo $query->value(); //return 'foo[0]=bar&foo[1]=baz'
 $new_query = $query->withoutNumericIndices();
 echo $new_query->value(); //return 'foo[]=bar&foo[]=baz'

--- a/docs/components/7.0/urlsearchparams.md
+++ b/docs/components/7.0/urlsearchparams.md
@@ -43,7 +43,7 @@ or one of the more specialized named constructors to avoid subtle bugs described
 - The `URLSearchParams::fromUri` instantiate from a URI.
 - The `URLSearchParams::fromPairs` instantiate from a collection of pairs.
 - The `URLSearchParams::fromAssociative` instantiate from an associative array or any object with public properties or generic key/value iterator (nested value are not supported).
-- The `URLSearchParams::fromPhpVariable` instantiate from the result of `parse_str` or the input of `http_build_query`.
+- The `URLSearchParams::fromVariable` instantiate from the result of `parse_str` or the input of `http_build_query`.
 
 ```php
 $parameters = [
@@ -55,7 +55,7 @@ $parameters = [
     ],
 ];
 
-$params = URLSearchParams::fromPhpVariable($parameters);
+$params = URLSearchParams::fromVariable($parameters);
 $params->get('filter[dateRange][start]'); //returns '2023-01-01
 echo $params; 
 //display "filter%5BdateRange%5D%5Bstart%5D=2023-01-01&filter%5BdateRange%5D%5Bend%5D=2023-08-31"
@@ -68,7 +68,7 @@ echo URLSearchParams::fromAssociative($interval)->toString();
 <p class="message-warning"> To adhere to the specification, if a string starts with the character <code>?</code>;
 <code>URLSearchParams::new</code> will ignore it before parsing the string.</p>
 
-<p class="message-info"><code>URLSearchParams::fromPhpVariable</code> replaced the deprecated 
+<p class="message-info"><code>URLSearchParams::fromVariable</code> replaced the deprecated 
 <code>URLSearchParams::fromParameters</code> named constructor which was
 not inconsistent against <code>http_build_query</code> algorithm.</p>
 

--- a/docs/components/7.0/urlsearchparams.md
+++ b/docs/components/7.0/urlsearchparams.md
@@ -43,7 +43,7 @@ or one of the more specialized named constructors to avoid subtle bugs described
 - The `URLSearchParams::fromUri` instantiate from a URI.
 - The `URLSearchParams::fromPairs` instantiate from a collection of pairs.
 - The `URLSearchParams::fromAssociative` instantiate from an associative array or any object with public properties or generic key/value iterator (nested value are not supported).
-- The `URLSearchParams::fromParameters` instantiate from the result of `parse_str` or the input of `http_build_query`.
+- The `URLSearchParams::fromPhpVariable` instantiate from the result of `parse_str` or the input of `http_build_query`.
 
 ```php
 $parameters = [
@@ -55,7 +55,7 @@ $parameters = [
     ],
 ];
 
-$params = URLSearchParams::fromParameters($parameters);
+$params = URLSearchParams::fromPhpVariable($parameters);
 $params->get('filter[dateRange][start]'); //returns '2023-01-01
 echo $params; 
 //display "filter%5BdateRange%5D%5Bstart%5D=2023-01-01&filter%5BdateRange%5D%5Bend%5D=2023-08-31"
@@ -67,6 +67,10 @@ echo URLSearchParams::fromAssociative($interval)->toString();
 
 <p class="message-warning"> To adhere to the specification, if a string starts with the character <code>?</code>;
 <code>URLSearchParams::new</code> will ignore it before parsing the string.</p>
+
+<p class="message-info"><code>URLSearchParams::fromPhpVariable</code> replaced the deprecated 
+<code>URLSearchParams::fromParameters</code> named constructor which was
+not inconsistent against <code>http_build_query</code> algorithm.</p>
 
 ```php
 use League\Uri\Components\URLSearchParams;


### PR DESCRIPTION
- [X] `Query::fromParameters` now works with `URLSearchParams` object.
- [X] `URLSearchParams::fromParameters` now encodes parameters according to the WHATWG group specification and no longer like http_build_query.