### PR TITLE
Adding BaseUri::unixPath and BaseUri::windowsPath

### DIFF
--- a/docs/uri/7.0/base-uri.md
+++ b/docs/uri/7.0/base-uri.md
@@ -195,3 +195,19 @@ use League\Uri\BaseUri;
 
 BaseUri::from((Http::new('/path/to/endpoint'))->origin(); //returns null
 ~~~
+
+### BaseUri::unixPath and BaseUri::windowsPath
+
+<p class="message-notice">since version <code>7.3.0</code></p>
+
+Returns the OS specific path from a URI.
+
+~~~php
+BaseUri::from('file://server/share/My%20Documents%20100%2520/foo.txt')->windowsPath();
+//returns '\\server\share\My Documents 100%20\foo.txt'
+
+BaseUri::from('file:///path%20empty/bar')->unixPath();
+//returns '/path empty/bar'
+~~~
+
+If the URI scheme is present and is not the `file` scheme, `null` will be returned,

--- a/uri/BaseUriTest.php
+++ b/uri/BaseUriTest.php
@@ -488,4 +488,91 @@ final class BaseUriTest extends TestCase
             'expected' => false,
         ];
     }
+
+    /** @dataProvider unixpathProvider */
+    public function testReturnsUnixPath(?string $expected, string $input): void
+    {
+        self::assertSame($expected, BaseUri::from($input)->unixPath());
+        self::assertSame($expected, BaseUri::from(Utils::uriFor($input))->unixPath());
+    }
+
+    public static function unixpathProvider(): array
+    {
+        return [
+            'relative path' => [
+                'expected' => 'path',
+                'input' => 'path',
+            ],
+            'absolute path' => [
+                'expected' => '/path',
+                'inout' => 'file:///path',
+            ],
+            'path with empty char' => [
+                'expected' => '/path empty/bar',
+                'inout' => 'file:///path%20empty/bar',
+            ],
+            'relative path with dot segments' => [
+                'expected' => 'path/./relative',
+                'input' => 'path/./relative',
+            ],
+            'absolute path with dot segments' => [
+                'expected' => '/path/./../relative',
+                'input' => 'file:///path/./../relative',
+            ],
+            'unsupported scheme' => [
+                'expected' => null,
+                'input' => 'http://example.com/foo/bar',
+            ],
+        ];
+    }
+
+    /** @dataProvider windowLocalPathProvider */
+    public function testReturnsWindowsPath(?string $expected, string $input): void
+    {
+        self::assertSame($expected, BaseUri::from($input)->windowsPath());
+        self::assertSame($expected, BaseUri::from(Utils::uriFor($input))->windowsPath());
+
+    }
+
+    public static function windowLocalPathProvider(): array
+    {
+        return [
+            'relative path' => [
+                'expected' => 'path',
+                'input' => 'path',
+            ],
+            'relative path with dot segments' => [
+                'expected' => 'path\.\relative',
+                'input' => 'path/./relative',
+            ],
+            'absolute path' => [
+                'expected' => 'c:\windows\My Documents 100%20\foo.txt',
+                'input' => 'file:///c:/windows/My%20Documents%20100%2520/foo.txt',
+            ],
+            'windows relative path' => [
+                'expected' => 'c:My Documents 100%20\foo.txt',
+                'input' => 'file:///c:My%20Documents%20100%2520/foo.txt',
+            ],
+            'absolute path with `|`' => [
+                'expected' => 'c:\windows\My Documents 100%20\foo.txt',
+                'input' => 'file:///c:/windows/My%20Documents%20100%2520/foo.txt',
+            ],
+            'windows relative path with `|`' => [
+                'expected' => 'c:My Documents 100%20\foo.txt',
+                'input' => 'file:///c:My%20Documents%20100%2520/foo.txt',
+            ],
+            'absolute path with dot segments' => [
+                'expected' => '\path\.\..\relative',
+                'input' => '/path/./../relative',
+            ],
+            'absolute UNC path' => [
+                'expected' => '\\\\server\share\My Documents 100%20\foo.txt',
+                'input' => 'file://server/share/My%20Documents%20100%2520/foo.txt',
+            ],
+            'unsupported scheme' => [
+                'expected' => null,
+                'input' => 'http://example.com/foo/bar',
+            ],
+        ];
+    }
 }

--- a/uri/CHANGELOG.md
+++ b/uri/CHANGELOG.md
@@ -6,7 +6,8 @@ All Notable changes to `League\Uri` will be documented in this file
 
 ### Added
 
-- None
+- `BaseUri::unixPath`
+- `BaseUri::windowsPath`
 
 ### Fixed
 


### PR DESCRIPTION
This PR resolve #124 by adding two new methods to `BaseUri`:

- `BaseUri::windowsPath`
- `BaseUri::unixPath`

The conversion can only be made if there is no scheme **OR** if the scheme is `file`. For any other scheme the methods will return `null`.