### PR TITLE
Fix typo in exception message about invalid path parameters

### DIFF
--- a/uri/Uri.php
+++ b/uri/Uri.php
@@ -791,7 +791,7 @@ final class Uri implements UriInterface
 
         $res = array_filter(array_filter(explode(';', $parameters), self::validateParameter(...)));
         if ([] !== $res) {
-            throw new SyntaxError('The path paremeters `'.$parameters.'` is invalid.');
+            throw new SyntaxError('The path parameters `'.$parameters.'` is invalid.');
         }
 
         if (!$isBinary) {


### PR DESCRIPTION
I just noticed it and thought I give it a fix. I've read the contributing guidelines and I assume I fulfil all cases except the tests but I feel, that an exception message test for not having typos is a helpful thing to test for. If you want one though, I am happy to add one.

Sidenote; This shall not be spam or "too easy to count" regarding hacktoberfest. I already have my four pull requests for hacktoberfest in public.