### PR TITLE
Improve internal codebase

### DIFF
--- a/components/CHANGELOG.md
+++ b/components/CHANGELOG.md
@@ -12,10 +12,11 @@ All Notable changes to `League\Uri\Components` will be documented in this file
 ### Fixed
 
 - Adding `SensitiveParameter` attribute in the `UserInfo` and the `Authority` class.
+- Remove Usage of PSR-7 `UriInterface` in `UrlSearchParams` class
 
 ### Deprecated
 
-- None
+- Usage of PSR-7 `UriFactoryInterface` is deprecated in `Modifier` class
 
 ### Removed
 

--- a/components/CHANGELOG.md
+++ b/components/CHANGELOG.md
@@ -8,6 +8,8 @@ All Notable changes to `League\Uri\Components` will be documented in this file
 
 - `UrlSearchParams::uniqueKeyCount`
 - `Modifier::getIdnUriString`
+- `Modifier::hostToIpv6Compressed`
+- `Modifier::hostToIpv6Expanded`
 
 ### Fixed
 

--- a/components/CHANGELOG.md
+++ b/components/CHANGELOG.md
@@ -11,7 +11,7 @@ All Notable changes to `League\Uri\Components` will be documented in this file
 
 ### Fixed
 
-- None
+- Adding `SensitiveParameter` attribute in the `UserInfo` and the `Authority` class.
 
 ### Deprecated
 

--- a/components/Components/Authority.php
+++ b/components/Components/Authority.php
@@ -21,6 +21,7 @@ use League\Uri\Contracts\UserInfoInterface;
 use League\Uri\Exceptions\SyntaxError;
 use League\Uri\UriString;
 use Psr\Http\Message\UriInterface as Psr7UriInterface;
+use SensitiveParameter;
 use Stringable;
 
 final class Authority extends Component implements AuthorityInterface
@@ -32,7 +33,7 @@ final class Authority extends Component implements AuthorityInterface
     public function __construct(
         Stringable|string|null $host,
         Stringable|string|int|null $port = null,
-        Stringable|string|null $userInfo = null
+        #[SensitiveParameter] Stringable|string|null $userInfo = null
     ) {
         $this->host = !$host instanceof HostInterface ? Host::new($host) : $host;
         $this->port = !$port instanceof PortInterface ? Port::new($port) : $port;
@@ -45,7 +46,7 @@ final class Authority extends Component implements AuthorityInterface
     /**
      * @throws SyntaxError If the component contains invalid HostInterface part.
      */
-    public static function new(Stringable|string|null $value = null): self
+    public static function new(#[SensitiveParameter] Stringable|string|null $value = null): self
     {
         $components = UriString::parseAuthority(self::filterComponent($value));
 
@@ -62,7 +63,7 @@ final class Authority extends Component implements AuthorityInterface
     /**
      * Create a new instance from a URI object.
      */
-    public static function fromUri(Stringable|string $uri): self
+    public static function fromUri(#[SensitiveParameter] Stringable|string $uri): self
     {
         $uri = self::filterUri($uri);
         $authority = $uri->getAuthority();
@@ -87,7 +88,7 @@ final class Authority extends Component implements AuthorityInterface
      *     port? : ?int
      * } $components
      */
-    public static function fromComponents(array $components): self
+    public static function fromComponents(#[SensitiveParameter] array $components): self
     {
         $components += ['user' => null, 'pass' => null, 'host' => null, 'port' => null];
 
@@ -104,7 +105,7 @@ final class Authority extends Component implements AuthorityInterface
     }
 
     private static function getAuthorityValue(
-        UserInfoInterface $userInfo,
+        #[SensitiveParameter] UserInfoInterface $userInfo,
         HostInterface $host,
         PortInterface $port
     ): ?string {
@@ -180,7 +181,7 @@ final class Authority extends Component implements AuthorityInterface
         };
     }
 
-    public function withUserInfo(Stringable|string|null $user, Stringable|string|null $password = null): AuthorityInterface
+    public function withUserInfo(Stringable|string|null $user, #[SensitiveParameter] Stringable|string|null $password = null): AuthorityInterface
     {
         $userInfo = new UserInfo($user, $password);
 
@@ -200,7 +201,7 @@ final class Authority extends Component implements AuthorityInterface
      *
      * Create a new instance from a URI object.
      */
-    public static function createFromUri(UriInterface|Psr7UriInterface $uri): self
+    public static function createFromUri(#[SensitiveParameter] UriInterface|Psr7UriInterface $uri): self
     {
         return self::fromUri($uri);
     }
@@ -215,7 +216,7 @@ final class Authority extends Component implements AuthorityInterface
      *
      * Returns a new instance from a string or a stringable object.
      */
-    public static function createFromString(Stringable|string $authority): self
+    public static function createFromString(#[SensitiveParameter] Stringable|string $authority): self
     {
         return self::new($authority);
     }
@@ -255,7 +256,7 @@ final class Authority extends Component implements AuthorityInterface
      *     port? : ?int
      * } $components
      */
-    public static function createFromComponents(array $components): self
+    public static function createFromComponents(#[SensitiveParameter] array $components): self
     {
         return self::fromComponents($components);
     }

--- a/components/Components/Host.php
+++ b/components/Components/Host.php
@@ -22,6 +22,7 @@ use League\Uri\Exceptions\SyntaxError;
 use League\Uri\Idna\Converter as IdnConverter;
 use League\Uri\IPv4\Converter as IPv4Converter;
 use League\Uri\IPv4Normalizer;
+use League\Uri\IPv6\Converter;
 use Psr\Http\Message\UriInterface as Psr7UriInterface;
 use Stringable;
 

--- a/components/Components/URLSearchParams.php
+++ b/components/Components/URLSearchParams.php
@@ -25,7 +25,6 @@ use League\Uri\Exceptions\SyntaxError;
 use League\Uri\KeyValuePair\Converter;
 use League\Uri\QueryString;
 use League\Uri\Uri;
-use Psr\Http\Message\UriInterface as Psr7UriInterface;
 use Stringable;
 
 use function array_is_list;
@@ -202,7 +201,6 @@ final class URLSearchParams implements Countable, IteratorAggregate, UriComponen
     public static function fromUri(Stringable|string $uri): self
     {
         $query = match (true) {
-            $uri instanceof Psr7UriInterface,
             $uri instanceof UriInterface => $uri->getQuery(),
             default => Uri::new($uri)->getQuery(),
         };

--- a/components/Components/UserInfo.php
+++ b/components/Components/UserInfo.php
@@ -50,7 +50,7 @@ final class UserInfo extends Component implements UserInfoInterface
     /**
      * Create a new instance from a URI object.
      */
-    public static function fromUri(Stringable|string $uri): self
+    public static function fromUri(#[SensitiveParameter] Stringable|string $uri): self
     {
         $uri = self::filterUri($uri);
         $component = $uri->getUserInfo();
@@ -64,7 +64,7 @@ final class UserInfo extends Component implements UserInfoInterface
     /**
      * Create a new instance from an Authority object.
      */
-    public static function fromAuthority(Stringable|string|null $authority): self
+    public static function fromAuthority(#[SensitiveParameter] Stringable|string|null $authority): self
     {
         return match (true) {
             $authority instanceof AuthorityInterface => self::new($authority->getUserInfo()),
@@ -80,7 +80,7 @@ final class UserInfo extends Component implements UserInfoInterface
      *
      * @param array{user? : ?string, pass? : ?string} $components
      */
-    public static function fromComponents(array $components): self
+    public static function fromComponents(#[SensitiveParameter] array $components): self
     {
         $components += ['user' => null, 'pass' => null];
 
@@ -93,7 +93,7 @@ final class UserInfo extends Component implements UserInfoInterface
     /**
      * Creates a new instance from an encoded string.
      */
-    public static function new(Stringable|string|null $value = null): self
+    public static function new(#[SensitiveParameter] Stringable|string|null $value = null): self
     {
         if ($value instanceof UriComponentInterface) {
             $value = $value->value();
@@ -176,7 +176,7 @@ final class UserInfo extends Component implements UserInfoInterface
      *
      * Create a new instance from a URI object.
      */
-    public static function createFromUri(Psr7UriInterface|UriInterface $uri): self
+    public static function createFromUri(#[SensitiveParameter] Psr7UriInterface|UriInterface $uri): self
     {
         return self::fromUri($uri);
     }
@@ -191,7 +191,7 @@ final class UserInfo extends Component implements UserInfoInterface
      *
      * Create a new instance from an Authority object.
      */
-    public static function createFromAuthority(AuthorityInterface|Stringable|string $authority): self
+    public static function createFromAuthority(#[SensitiveParameter] AuthorityInterface|Stringable|string $authority): self
     {
         return self::fromAuthority($authority);
     }
@@ -206,7 +206,7 @@ final class UserInfo extends Component implements UserInfoInterface
      *
      * Creates a new instance from an encoded string.
      */
-    public static function createFromString(Stringable|string $userInfo): self
+    public static function createFromString(#[SensitiveParameter] Stringable|string $userInfo): self
     {
         return self::new($userInfo);
     }

--- a/components/Components/UserInfo.php
+++ b/components/Components/UserInfo.php
@@ -113,9 +113,8 @@ final class UserInfo extends Component implements UserInfoInterface
     public function value(): ?string
     {
         return match (true) {
-            null === $this->username => null,
-            null === $this->password => Encoder::encodeUser($this->username),
-            default => Encoder::encodeUser($this->username).':'.Encoder::encodePassword($this->password),
+            null === $this->password => $this->getUsername(),
+            default => $this->getUsername().':'.$this->getPassword(),
         };
     }
 
@@ -132,6 +131,22 @@ final class UserInfo extends Component implements UserInfoInterface
     public function getPass(): ?string
     {
         return $this->password;
+    }
+
+    public function getUsername(): ?string
+    {
+        return match ($this->username) {
+            null => null,
+            default => Encoder::encodeUser($this->username)
+        };
+    }
+
+    public function getPassword(): ?string
+    {
+        return match ($this->password) {
+            null => null,
+            default => Encoder::encodePassword($this->password)
+        };
     }
 
     /**

--- a/components/Modifier.php
+++ b/components/Modifier.php
@@ -26,6 +26,7 @@ use League\Uri\Contracts\UriInterface;
 use League\Uri\Exceptions\SyntaxError;
 use League\Uri\Idna\Converter as IdnConverter;
 use League\Uri\IPv4\Converter as IPv4Converter;
+use League\Uri\IPv6\Converter;
 use League\Uri\KeyValuePair\Converter as KeyValuePairConverter;
 use Psr\Http\Message\UriFactoryInterface;
 use Psr\Http\Message\UriInterface as Psr7UriInterface;
@@ -449,6 +450,20 @@ class Modifier implements Stringable, JsonSerializable, UriAccess
             $currentHost === $hostIp  => $this,
             default => new static($this->uri->withHost($hostIp)),
         };
+    }
+
+    public function hostToIpv6Compressed(): static
+    {
+        return new static($this->uri->withHost(
+            Converter::compress($this->uri->getHost())
+        ));
+    }
+
+    public function hostToIpv6Expanded(): static
+    {
+        return new static($this->uri->withHost(
+            Converter::expand($this->uri->getHost())
+        ));
     }
 
     /**

--- a/components/Modifier.php
+++ b/components/Modifier.php
@@ -43,6 +43,12 @@ class Modifier implements Stringable, JsonSerializable, UriAccess
     {
     }
 
+    /**
+     * @param Stringable|string $uri
+     * @param UriFactoryInterface|null $uriFactory Deprecated, will be removed in the next major release
+     *
+     * @return static
+     */
     public static function from(Stringable|string $uri, ?UriFactoryInterface $uriFactory = null): static
     {
         return new static(match (true) {

--- a/docs/_data/menu.yml
+++ b/docs/_data/menu.yml
@@ -29,6 +29,7 @@ packages:
                 URI Parser: '/interfaces/7.0/uri-parser-builder/'
                 Query Parser: '/interfaces/7.0/query-parser-builder/'
                 IPv4 Converter: '/interfaces/7.0/ipv4/'
+                IPv6 Converter: '/interfaces/7.0/ipv6/'
                 IDN Converter: '/interfaces/7.0/idn/'
         '2.0':
             Documentation:

--- a/docs/components/7.0/modifiers.md
+++ b/docs/components/7.0/modifiers.md
@@ -368,6 +368,36 @@ echo Modifier::from($uri)->hostToOctal()->getUri();
 //display 'http://0xc0a811/path/to/the/sky.php'
 ~~~
 
+### Modifier::hostToIpv6Compressed
+
+Normalizes the URI host content to a compressed IPv6 notation if possible.
+See the [IPv6 Converter documentation](/components/7.0/ipv6/) page for more information.
+
+~~~php
+<?php
+
+use League\Uri\Modifier;
+
+$uri = 'http://[1050:0000:0000:0000:0005:0000:300c:326b]/path/to/the/sky.php';
+echo Modifier::from($uri)->hostToIpv6Compressed()->getUriString();
+//display 'http://[1050::5:0:300c:326b]/path/to/the/sky.php'
+~~~
+
+### Modifier::hostToIpv6Expanded
+
+Normalizes the URI host content to a expanded IPv6 notation if possible.
+See the [IPv6 Converter documentation](/components/7.0/ipv6/) page for more information.
+
+~~~php
+<?php
+
+use League\Uri\Modifier;
+
+$uri = 'http://[0000:0000:0000:0000:0000:0000:0000:0001]/path/to/the/sky.php';
+echo Modifier::from($uri)->hostToIpv6Compressed()->getUriString();
+//display 'http://[::1]/path/to/the/sky.php'
+~~~
+
 ### Modifier::removeZoneIdentifier
 
 Removes the host zone identifier if present

--- a/docs/interfaces/7.0/contracts.md
+++ b/docs/interfaces/7.0/contracts.md
@@ -27,6 +27,8 @@ The `UriInterface` interface defines the following methods to access the URI str
 
 public UriInterface::getScheme(): ?string
 public UriInterface::getUserInfo(): ?string
+public UriInterface::getUsername(): ?string
+public UriInterface::getPassword(): ?string
 public UriInterface::getHost(): ?string
 public UriInterface::getPort(): ?int
 public UriInterface::getAuthority(): ?string
@@ -51,7 +53,7 @@ Delimiter characters are not part of the URI component and **must not** be added
 <?php
 
 public UriInterface::withScheme(Stringable|string|null $scheme): self
-public UriInterface::withUserInfo(Stringable|string|null $user [, string $password = null]): self
+public UriInterface::withUserInfo(Stringable|string|null $user [, Stringable|string|null $password = null]): self
 public UriInterface::withHost(Stringable|string|null $host): self
 public UriInterface::withPort(?int $port): self
 public UriInterface::withPath(Stringable|string $path): self
@@ -64,8 +66,8 @@ public UriInterface::withFragment(Stringable|string|null $fragment): self
 This interface exposes the same methods as `Psr\Http\Message\UriInterface`. But, differs on the following keys:
 
 - This interface does not require the `http` and `https` schemes to be supported.
-- Setter and Getter component methods, with the exception of the path component, accept and can return the `null` value.
-- If no scheme is present, you are not required to fallback to `http` and `https` schemes specific validation rules.
+- Setter and Getter component methods, except the path component, accept and can return the `null` value.
+- If no scheme is present, the requirement to fall back to `http` and `https` schemes specific validation rules is not enforced.
 
 ### League\Uri\Contract\UriComponentInterface
 
@@ -78,7 +80,7 @@ The `UriComponentInterface` interface defines the following methods to access th
 ~~~php
 <?php
 public UriComponentInterface::value(): ?string
-public UriComponentInterface::toString(): ?string
+public UriComponentInterface::toString(): string
 public UriComponentInterface::getUriComponent(): ?string
 public UriComponentInterface::jsonSerialize(): ?string
 public UriComponentInterface::__toString(): string

--- a/docs/interfaces/7.0/ipv6.md
+++ b/docs/interfaces/7.0/ipv6.md
@@ -1,0 +1,41 @@
+---
+layout: default
+title: IPv6 Converter
+---
+
+IPv6 Converter
+=======
+
+The `League\Uri\IPv6\Converter` is a IPv6 Converter.
+
+```php
+<?php
+
+use League\Uri\IPv6\Converter;
+
+echo Converter::expand('[::1]');
+// returns '[0000:0000:0000:0000:0000:0000:0000:0001]'
+echo Converter::compress('[1050:0000:0000:0000:0005:0000:300c:326b]');
+// returns [1050::5:0:300c:326b]
+```
+
+Usage
+--------
+
+The `Converter::compress` method convert an expanded IPv6 host into its compressed form.  
+The method only parameter should represent a host value. The `Converter::exoend` method
+does the opposite.
+
+If you submit a host which is not an IPv6 one then, the submitted host value will be returned
+as is.Conversely, trying to expand an IPv6 host which is already expanded or trying to compress
+an already compressed IPv6 host will return the same value so nothing will be gain performing
+such obvious operation.
+
+```php
+<?php
+
+echo Converter::compress('[::1]'); 
+// returns '[::1]'
+echo Converter::expand('[1050:0000:0000:0000:0005:0000:300c:326b]');
+// returns [1050:0000:0000:0000:0005:0000:300c:326b]
+```

--- a/docs/uri/7.0/base-uri.md
+++ b/docs/uri/7.0/base-uri.md
@@ -30,19 +30,6 @@ echo $baseUri; // display 'http://www.example.com'
 
 The instance also implements PHP's `Stringable` and `JsonSerializable` interface.
 
-Since version `7.5` it is possible to use the `getIdnUriString` to get the URI with its host in its
-internationalized string format.
-
-~~~php
-<?php
-
-use League\Uri\BaseUri;
-
-$baseUri = BaseUri::from('http://www.bébé.be');
-$baseUri->getUriString(); // return 'http://xn--bb-bjab.be'
-$baseUri->getIdnUriString(); // display 'http://www.bébé.be'
-~~~
-
 ## URI resolution
 
 The `BaseUri::resolve` resolves a URI as a browser would for a relative URI while

--- a/interfaces/CHANGELOG.md
+++ b/interfaces/CHANGELOG.md
@@ -6,11 +6,12 @@ All Notable changes to `League\Uri\Interfaces` will be documented in this file
 
 ### Added
 
-- `UriAccess::getIdnUriString`
+- `UriInterface::getUsername` returns the encoded user component of the URI.
+- `UriInterface::getPassword` returns the encoded scheme-specific information about how to gain authorization to access the resource.
 
 ### Fixed
 
-- None
+- Adding Host resolution caching to speed up URI parsing in `UriString`
 
 ### Deprecated
 

--- a/interfaces/CHANGELOG.md
+++ b/interfaces/CHANGELOG.md
@@ -8,6 +8,7 @@ All Notable changes to `League\Uri\Interfaces` will be documented in this file
 
 - `UriInterface::getUsername` returns the encoded user component of the URI.
 - `UriInterface::getPassword` returns the encoded scheme-specific information about how to gain authorization to access the resource.
+- `Uri\IPv6\Converter` allow expanding and compressing IPv6.
 
 ### Fixed
 

--- a/interfaces/Contracts/UriAccess.php
+++ b/interfaces/Contracts/UriAccess.php
@@ -15,9 +15,6 @@ namespace League\Uri\Contracts;
 
 use Psr\Http\Message\UriInterface as Psr7UriInterface;
 
-/**
- * @method string getIdnUriString() returns the RFC3986 string representation of the complete URI with its host in IDNA form
- */
 interface UriAccess
 {
     public function getUri(): UriInterface|Psr7UriInterface;

--- a/interfaces/Contracts/UriInterface.php
+++ b/interfaces/Contracts/UriInterface.php
@@ -21,6 +21,9 @@ use Stringable;
 
 /**
  * @phpstan-import-type ComponentMap from UriString
+ *
+ * @method string|null getUsername() returns the user component of the URI.
+ * @method string|null getPassword() returns the scheme-specific information about how to gain authorization to access the resource.
  */
 interface UriInterface extends JsonSerializable, Stringable
 {

--- a/interfaces/IPv6/Converter.php
+++ b/interfaces/IPv6/Converter.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace League\Uri\IPv6;
+
+use Stringable;
+use ValueError;
+use const FILTER_FLAG_IPV6;
+use const FILTER_VALIDATE_IP;
+
+use function filter_var;
+use function inet_pton;
+use function implode;
+use function str_split;
+use function strtolower;
+use function unpack;
+
+final class Converter
+{
+    public static function compressIp(string $ipv6): string
+    {
+        if (false === filter_var($ipv6, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6)) {
+            throw new ValueError('The submitted IP is not a valid IPv6 address.');
+        }
+
+        return (string) inet_ntop((string) inet_pton($ipv6));
+    }
+
+    public static function expandIp(string $ipv6): string
+    {
+        if (false === filter_var($ipv6, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6)) {
+            throw new ValueError('The submitted IP is not a valid IPv6 address.');
+        }
+
+        $hex = (array) unpack("H*hex", (string) inet_pton($ipv6));
+
+        return implode(':', str_split(strtolower($hex['hex'] ?? ''), 4));
+    }
+
+    public static function compress(Stringable|string|null $host): ?string
+    {
+        $components = self::parse($host);
+        if (null === $components['ipv6']) {
+            return match ($host) {
+                null => $host,
+                default => (string) $host,
+            };
+        }
+
+        $components['ipv6'] = self::compressIp($components['ipv6']);
+
+        return self::build($components);
+    }
+
+    public static function expand(Stringable|string|null $host): ?string
+    {
+        $components = self::parse($host);
+        if (null === $components['ipv6']) {
+            return match ($host) {
+                null => $host,
+                default => (string) $host,
+            };
+        }
+
+        $components['ipv6'] = self::expandIp($components['ipv6']);
+
+        return self::build($components);
+    }
+
+    private static function build(array $components): string
+    {
+        $components['ipv6'] ??= null;
+        $components['zoneIdentifier'] ??= null;
+
+        return '['.$components['ipv6'].match ($components['zoneIdentifier']) {
+            null => '',
+            default => '%'.$components['zoneIdentifier'],
+        }.']';
+    }
+
+    /**]
+     * @param Stringable|string|null $host
+     *
+     * @return array{ipv6:?string, zoneIdentifier:?string}
+     */
+    private static function parse(Stringable|string|null $host): array
+    {
+        if ($host === null) {
+            return ['ipv6' => null, 'zoneIdentifier' => null];
+        }
+
+        $host = (string) $host;
+        if ($host === '') {
+            return ['ipv6' => null, 'zoneIdentifier' => null];
+        }
+
+        if (!str_starts_with($host, '[')) {
+            return ['ipv6' => null, 'zoneIdentifier' => null];
+        }
+
+        if (!str_ends_with($host, ']')) {
+            return ['ipv6' => null, 'zoneIdentifier' => null];
+        }
+
+        [$ipv6, $zoneIdentifier] = explode('%', substr($host, 1, -1), 2) + [1 => null];
+        if (false === filter_var($ipv6, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6)) {
+            return ['ipv6' => null, 'zoneIdentifier' => null];
+        }
+
+        return ['ipv6' => $ipv6, 'zoneIdentifier' => $zoneIdentifier];
+    }
+}

--- a/interfaces/IPv6/ConverterTest.php
+++ b/interfaces/IPv6/ConverterTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace League\Uri\IPv6;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use ValueError;
+
+final class ConverterTest extends TestCase
+{
+    #[DataProvider('ipv6NormalizationUriProvider')]
+    public function testItCanExpandOrCompressTheHost(
+        string $ipv6,
+        string $ipv6Compressed,
+        string $ipv6Expanded,
+    ): void {
+
+        self::assertSame($ipv6Compressed, Converter::compress($ipv6));
+        self::assertSame($ipv6Expanded, Converter::expand($ipv6));
+    }
+
+    public static function ipv6NormalizationUriProvider(): iterable
+    {
+        yield 'no change happen with a non IP ipv6' => [
+            'ipv6' => 'example.com',
+            'ipv6Compressed' => 'example.com',
+            'ipv6Expanded' => 'example.com',
+        ];
+
+        yield 'no change happen with a IPv4 ipv6' => [
+            'ipv6' => '127.0.0.1',
+            'ipv6Compressed' => '127.0.0.1',
+            'ipv6Expanded' => '127.0.0.1',
+        ];
+
+        yield 'IPv6 gets expanded if needed' => [
+            'ipv6' => '[fe80::a%25en1]',
+            'ipv6Compressed' => '[fe80::a%25en1]',
+            'ipv6Expanded' => '[fe80:0000:0000:0000:0000:0000:0000:000a%25en1]',
+        ];
+
+        yield 'IPv6 gets compressed if needed' => [
+            'ipv6' => '[0000:0000:0000:0000:0000:0000:0000:0001]',
+            'ipv6Compressed' => '[::1]',
+            'ipv6Expanded' => '[0000:0000:0000:0000:0000:0000:0000:0001]',
+        ];
+    }
+
+    #[DataProvider('invalidIpv6')]
+    public function testItFailsToCompressANonIpv6(string $invalidIp): void
+    {
+        $this->expectException(ValueError::class);
+
+        Converter::compressIp($invalidIp);
+    }
+
+    #[DataProvider('invalidIpv6')]
+    public function testItFailsToExpandANonIpv6(string $invalidIp): void
+    {
+         $this->expectException(ValueError::class);
+
+         Converter::expandIp($invalidIp);
+    }
+
+    public static function invalidIpv6(): iterable
+    {
+        yield 'hostname' => ['invalidIp' => 'example.com'];
+
+        yield 'IPv4' => ['invalidIp' => '127.0.0.2'];
+
+        yield 'ip future' => ['invalidIp' => '[v42.fdfsffd]'];
+
+        yield 'IPv6 with zoneIdentifier' => ['invalidIp' => 'fe80::a%25en1'];
+    }
+}

--- a/interfaces/UriString.php
+++ b/interfaces/UriString.php
@@ -48,6 +48,8 @@ final class UriString
 {
     /**
      * Default URI component values.
+     *
+     * @var ComponentMap
      */
     private const URI_COMPONENTS = [
         'scheme' => null, 'user' => null, 'pass' => null, 'host' => null,
@@ -56,6 +58,8 @@ final class UriString
 
     /**
      * Simple URI which do not need any parsing.
+     *
+     * @var array<string, array<string>>
      */
     private const URI_SHORTCUTS = [
         '' => [],
@@ -68,6 +72,8 @@ final class UriString
 
     /**
      * Range of invalid characters in URI string.
+     *
+     * @var string
      */
     private const REGEXP_INVALID_URI_CHARS = '/[\x00-\x1f\x7f]/';
 
@@ -75,6 +81,7 @@ final class UriString
      * RFC3986 regular expression URI splitter.
      *
      * @link https://tools.ietf.org/html/rfc3986#appendix-B
+     * @var string
      */
     private const REGEXP_URI_PARTS = ',^
         (?<scheme>(?<scontent>[^:/?\#]+):)?    # URI scheme component
@@ -88,6 +95,7 @@ final class UriString
      * URI scheme regular expression.
      *
      * @link https://tools.ietf.org/html/rfc3986#section-3.1
+     * @var string
      */
     private const REGEXP_URI_SCHEME = '/^([a-z][a-z\d+.-]*)?$/i';
 
@@ -95,6 +103,7 @@ final class UriString
      * IPvFuture regular expression.
      *
      * @link https://tools.ietf.org/html/rfc3986#section-3.2.2
+     * @var string
      */
     private const REGEXP_IP_FUTURE = '/^
         v(?<version>[A-F0-9])+\.
@@ -108,6 +117,7 @@ final class UriString
      * General registered name regular expression.
      *
      * @link https://tools.ietf.org/html/rfc3986#section-3.2.2
+     * @var string
      */
     private const REGEXP_REGISTERED_NAME = '/(?(DEFINE)
         (?<unreserved>[a-z0-9_~\-])   # . is missing as it is used to separate labels
@@ -121,6 +131,7 @@ final class UriString
      * Invalid characters in host regular expression.
      *
      * @link https://tools.ietf.org/html/rfc3986#section-3.2.2
+     * @var string
      */
     private const REGEXP_INVALID_HOST_CHARS = '/
         [:\/?#\[\]@ ]  # gen-delims characters as well as the space character
@@ -130,24 +141,38 @@ final class UriString
      * Invalid path for URI without scheme and authority regular expression.
      *
      * @link https://tools.ietf.org/html/rfc3986#section-3.3
+     * @var string
      */
     private const REGEXP_INVALID_PATH = ',^(([^/]*):)(.*)?/,';
 
     /**
      * Host and Port splitter regular expression.
+     *
+     * @var string
      */
     private const REGEXP_HOST_PORT = ',^(?<host>\[.*\]|[^:]*)(:(?<port>.*))?$,';
 
     /**
      * IDN Host detector regular expression.
+     *
+     * @var string
      */
     private const REGEXP_IDN_PATTERN = '/[^\x20-\x7f]/';
 
     /**
      * Only the address block fe80::/10 can have a Zone ID attach to
      * let's detect the link local significant 10 bits.
+     *
+     * @var string
      */
     private const ZONE_ID_ADDRESS_BLOCK = "\xfe\x80";
+
+    /**
+     * Maximum number of host cached.
+     *
+     * @var int
+     */
+    private const MAXIMUM_HOST_CACHED = 100;
 
     /**
      * Generate a URI string representation from its parsed representation
@@ -379,16 +404,38 @@ final class UriString
      */
     private static function filterHost(string $host): string
     {
-        return match (true) {
-            '' === $host => '',
-            '[' !== $host[0] || !str_ends_with($host, ']') => self::filterRegisteredName($host),
-            !self::isIpHost(substr($host, 1, -1)) => throw new SyntaxError(sprintf('Host `%s` is invalid : the IP host is malformed', $host)),
-            default => $host,
-        };
+        if ('' === $host) {
+            return $host;
+        }
+
+        /** @var array<string, 1> $hostCache */
+        static $hostCache = [];
+        if (isset($hostCache[$host])) {
+            return $host;
+        }
+
+        if (self::MAXIMUM_HOST_CACHED < count($hostCache)) {
+            array_shift($hostCache);
+        }
+
+        if ('[' !== $host[0] || !str_ends_with($host, ']')) {
+            self::filterRegisteredName($host);
+            $hostCache[$host] = 1;
+
+            return $host;
+        }
+
+        if (self::isIpHost(substr($host, 1, -1))) {
+            $hostCache[$host] = 1;
+
+            return $host;
+        }
+
+        throw new SyntaxError(sprintf('Host `%s` is invalid : the IP host is malformed', $host));
     }
 
     /**
-     * Returns whether the host is an IPv4 or a registered named.
+     * Throws if the host is not a registered name and not a valid IDN host
      *
      * @link https://tools.ietf.org/html/rfc3986#section-3.2.2
      *
@@ -396,11 +443,11 @@ final class UriString
      * @throws MissingFeature if IDN support or ICU requirement are not available or met.
      * @throws ConversionFailed if the submitted IDN host cannot be converted to a valid ascii form
      */
-    private static function filterRegisteredName(string $host): string
+    private static function filterRegisteredName(string $host): void
     {
         $formattedHost = rawurldecode($host);
         if (1 === preg_match(self::REGEXP_REGISTERED_NAME, $formattedHost)) {
-            return $host;
+            return;
         }
 
         //to test IDN host non-ascii characters must be present in the host
@@ -409,8 +456,6 @@ final class UriString
         }
 
         Converter::toAsciiOrFail($host);
-
-        return $host;
     }
 
     /**

--- a/uri/BaseUri.php
+++ b/uri/BaseUri.php
@@ -79,24 +79,6 @@ class BaseUri implements Stringable, JsonSerializable, UriAccess
         return $this->uri;
     }
 
-    public function getIdnUriString(): string
-    {
-        $currentHost = $this->uri->getHost();
-        if (null === $currentHost || '' === $currentHost) {
-            return $this->getUriString();
-        }
-
-        $host = Converter::toUnicode($currentHost)->domain();
-        if ($host === $currentHost) {
-            return $this->getUriString();
-        }
-
-        $components = $this->uri instanceof UriInterface ? $this->uri->getComponents() : UriString::parse($this->uri);
-        $components['host'] = $host;
-
-        return UriString::build($components);
-    }
-
     public function getUriString(): string
     {
         return $this->uri->__toString();

--- a/uri/BaseUri.php
+++ b/uri/BaseUri.php
@@ -51,6 +51,10 @@ class BaseUri implements Stringable, JsonSerializable, UriAccess
     protected readonly Psr7UriInterface|UriInterface|null $origin;
     protected readonly ?string $nullValue;
 
+    /**
+     * @param Psr7UriInterface|UriInterface $uri
+     * @param UriFactoryInterface|null $uriFactory Deprecated, will be removed in the next major release
+     */
     final protected function __construct(
         protected readonly Psr7UriInterface|UriInterface $uri,
         protected readonly ?UriFactoryInterface $uriFactory

--- a/uri/BaseUriTest.php
+++ b/uri/BaseUriTest.php
@@ -583,33 +583,4 @@ final class BaseUriTest extends TestCase
             ],
         ];
     }
-
-    #[DataProvider('idnUriProvider')]
-    public function testItReturnsTheCorrectUriString(string $expected, string $input): void
-    {
-        self::assertSame($expected, BaseUri::from($input)->getIdnUriString());
-    }
-
-    public static function idnUriProvider(): iterable
-    {
-        yield 'basic uri stays the same' => [
-          'expected' => 'http://example.com/foo/bar',
-          'input' => 'http://example.com/foo/bar',
-        ];
-
-        yield 'idn host are changed' => [
-            'expected' => "http://bébé.be",
-            'input' => "http://xn--bb-bjab.be",
-        ];
-
-        yield 'idn host are the same' => [
-            'expected' => "http://bébé.be",
-            'input' => "http://bébé.be",
-        ];
-
-        yield 'the rest of the URI is not affected and uses RFC3986 rules' => [
-            'expected' => "http://bébé.be?q=toto%20le%20h%C3%A9ros",
-            'input' => "http://bébé.be:80?q=toto le héros",
-        ];
-    }
 }

--- a/uri/CHANGELOG.md
+++ b/uri/CHANGELOG.md
@@ -15,7 +15,7 @@ All Notable changes to `League\Uri` will be documented in this file
 
 ### Deprecated
 
-- None
+- Usage of PSR-7 `UriFactoryInterface` is deprecated in `BaseUri` class
 
 ### Removed
 

--- a/uri/CHANGELOG.md
+++ b/uri/CHANGELOG.md
@@ -6,11 +6,12 @@ All Notable changes to `League\Uri` will be documented in this file
 
 ### Added
 
-- Adding `BaseUri::getIdnUriString`
+- `Uri::getUsername` returns the encoded user component of the URI.
+- `Uri::getPassword` returns the encoded password component of the URI.
 
 ### Fixed
 
-- None
+- Adding `SensitiveParameter` attribute in the `Uri` and the `BaseUri` class.
 
 ### Deprecated
 


### PR DESCRIPTION
Small improvements

### Additions

- Adding missing `SensitiveParameter` attribute
- Adding `Uri::getUsername` and `Uri::getPassword` (both methods return the encoded component). If you need to access the decoded value you should use the `UserInfo` class instead defined under the `Components` namespace.
- Adding `Ipv6\Converter` utility to compress or expand and IPv6 hostname.

### Improvement

- Adding an internal cache system to boost `UriString::parse` when parsing multiple similar domain.

### Removal

- Remove `BaseUri::getIdnUriString` method. The method never got included into an official release). `Modifier::getIdnUriString` remains. 