### PR TITLE
fix: correctly handle several IP-based URI

### DIFF
--- a/uri/UriTest.php
+++ b/uri/UriTest.php
@@ -1157,4 +1157,30 @@ class UriTest extends TestCase
         // Ensure file handle of \SplFileObject gets closed.
         unlink($newFilePath);
     }
+
+    #[Test]
+    #[DataProvider('zeroIpAddressProvider')]
+    public function it_can_parse_zero_ip_addresses(string $uriString, string $expectedHost, ?int $expectedPort, ?string $expectedScheme, string $expectedPath): void
+    {
+        $uri = Uri::new($uriString);
+        
+        self::assertSame($expectedHost, $uri->getHost());
+        self::assertSame($expectedPort, $uri->getPort());
+        self::assertSame($expectedScheme, $uri->getScheme());
+        self::assertSame($expectedPath, $uri->getPath());
+    }
+
+    public static function zeroIpAddressProvider(): array
+    {
+        return [
+            ['0.0.0.0', '0.0.0.0', null, null, ''],
+            ['http://0.0.0.0', '0.0.0.0', null, 'http', ''],
+            ['0.0.0.0:7700', '0.0.0.0', 7700, null, ''],
+            ['http://0.0.0.0:7700', '0.0.0.0', 7700, 'http', ''],
+            ['0.0.0.0/health', '0.0.0.0', null, null, '/health'],
+            ['0.0.0.0:7700/health', '0.0.0.0', 7700, null, '/health'],
+            ['http://0.0.0.0/health', '0.0.0.0', null, 'http', '/health'],
+            ['http://0.0.0.0:7700/health', '0.0.0.0', 7700, 'http', '/health'],
+        ];
+    }
 }


### PR DESCRIPTION
Hello! I noticed that the current `UriString` doesn't handle several IP-based URIs correctly when working with some internal network URLs. 

I added a test for all versions I could think off and modified the parsing in the UriString to account for them. Some of them already worked and some didn't causing an inconsistent experience. For example, before this PR `http://0.0.0.0:7700/blabla` worked, but `0.0.0.0:7700/blabla` didn't.

Let me know if any questions. Thanks!