### PR TITLE
Declare the uri-polyfill package as provide ext-uri

### DIFF
--- a/polyfill/composer.json
+++ b/polyfill/composer.json
@@ -35,6 +35,9 @@
         "league/uri-interfaces": ">=7.6",
         "rowbot/url": "^4.1.0"
     },
+    "provide": {
+        "ext-uri": "*"
+    },
     "suggest": {
         "ext-intl": "to handle IDN host with the best performance",
         "jeremykendall/php-domain-parser": "to resolve Public Suffix and Top Level Domain",


### PR DESCRIPTION
This allows installing this polyfill package to satisfy a requirement on ext-uri of another package.

When a package provides a polyfill for all of an extension, this is the best way to implement such polyfill. For instance, Symfony does that for its iconv or mbstring polyfills.