### PR TITLE
Preserve the root when removeDotSegments pops past it (RFC 3986 §5.2.4)

### DIFF
--- a/interfaces/UriString.php
+++ b/interfaces/UriString.php
@@ -425,6 +425,12 @@ final class UriString
             $newPath .= '/';
         }
 
+        // A ".." overshooting the root must not turn an absolute path into a
+        // rootless one; RFC3986 §5.2.4 keeps the leading slash (as BaseUri does).
+        if (str_starts_with($path, '/') && !str_starts_with($newPath, '/')) {
+            return '/'.$newPath;
+        }
+
         return $newPath;
     }
 

--- a/interfaces/UriStringTest.php
+++ b/interfaces/UriStringTest.php
@@ -1190,4 +1190,44 @@ final class UriStringTest extends TestCase
         self::assertSame('g:h', UriString::resolve('g:h', $baseUri));
         self::assertSame('foo:g', UriString::resolve('foo:g', $baseUri));
     }
+
+    #[DataProvider('removeDotSegmentsProvider')]
+    public function test_it_keeps_the_leading_slash_of_an_absolute_path(string $path, string $expected): void
+    {
+        self::assertSame($expected, UriString::removeDotSegments($path));
+    }
+
+    /**
+     * @return iterable<string, array{path: string, expected: string}>
+     */
+    public static function removeDotSegmentsProvider(): iterable
+    {
+        // A ".." popping past the root used to drop the leading slash, turning an
+        // absolute path into a rootless one (RFC 3986 §5.2.4 keeps the root).
+        yield 'overshoot single'      => ['path' => '/../a',            'expected' => '/a'];
+        yield 'overshoot deep'        => ['path' => '/a/b/../../../c',  'expected' => '/c'];
+        yield 'overshoot to root'     => ['path' => '/../../',          'expected' => '/'];
+        yield 'overshoot trailing'    => ['path' => '/../',             'expected' => '/'];
+        yield 'overshoot then dir'    => ['path' => '/../a/b',          'expected' => '/a/b'];
+        yield 'overshoot then dot'    => ['path' => '/.././g',          'expected' => '/g'];
+        yield 'bare dotdot absolute'  => ['path' => '/..',              'expected' => '/'];
+
+        // Absolute paths that never overshoot must be unchanged.
+        yield 'absolute plain'        => ['path' => '/a/b/../c',        'expected' => '/a/c'];
+        yield 'absolute mixed'        => ['path' => '/a/b/c/./../../g', 'expected' => '/a/g'];
+        yield 'absolute trailing dot' => ['path' => '/a/.',             'expected' => '/a/'];
+
+        // Relative paths must stay relative: the guard only restores a dropped
+        // root, it must not promote a rootless path to an absolute one.
+        yield 'relative plain'        => ['path' => 'a/b/../c',         'expected' => 'a/c'];
+        yield 'relative overshoot'    => ['path' => 'a/../b',           'expected' => 'b'];
+        yield 'relative leading dot'  => ['path' => './a',              'expected' => 'a'];
+        yield 'relative complex'      => ['path' => 'mid/content=5/../6', 'expected' => 'mid/6'];
+    }
+
+    public function test_it_keeps_the_root_when_normalizing_an_authority_less_uri(): void
+    {
+        self::assertSame('foo:/a', UriString::normalize('foo:/../a'));
+        self::assertSame('file:/etc/passwd', UriString::normalize('file:/../etc/passwd'));
+    }
 }


### PR DESCRIPTION
## Summary

`UriString::removeDotSegments()` drops the leading slash when a `..` segment pops past the root, turning an absolute path into a rootless (relative) one. Per RFC 3986 [§5.2.4](https://www.rfc-editor.org/rfc/rfc3986#section-5.2.4), popping at the root operates on the (empty) output buffer, so the leading `/` is preserved.

```php
UriString::removeDotSegments('/../a');           // "a"    — RFC: "/a"
UriString::removeDotSegments('/a/b/../../../c');  // "c"    — RFC: "/c"
UriString::removeDotSegments('/../../');          // ""     — RFC: "/"
```

The `explode('/')` + `array_reduce` shortcut represents the leading `/` as an empty first segment; when `..` triggers `array_pop`, that empty marker is removed along with a real segment, so the root is lost.

Because `foo:/../a` and `foo:a` identify different resources (absolute vs. rootless path, RFC 3986 §3.3), this is also visible through the public helpers:

```php
UriString::normalize('foo:/../a');                    // "foo:a"        — RFC: "foo:/a"
UriString::normalize('file:/../etc/passwd');          // "file:etc/passwd" — RFC: "file:/etc/passwd"
Path::new('/../a')->withoutDotSegments()->toString(); // "a"            — RFC: "/a"
```

## Fix

`BaseUri::removeDotSegments()` already carries this exact guard (with the comment *"added because some PSR-7 implementations do not respect RFC3986"*); it was never back-ported to the canonical `UriString` implementation. This restores the leading slash only when the input path was absolute:

```php
if (str_starts_with($path, '/') && !str_starts_with($newPath, '/')) {
    return '/'.$newPath;
}
```

## Scope / no regression

- `resolve()` is unchanged: it already re-prepends `/` for URIs with an authority, so resolution was correct and stays byte-identical. The full RFC 3986 §5.4 resolution corpus (`resolveProvider`, `extraResolutionProvider`) still passes.
- The guard fires only when an absolute path would otherwise become rootless. Relative paths stay relative (`a/../b` -> `b`) and non-overshoot paths are untouched (`/a/b/../c` -> `/a/c`), so no existing behaviour changes.
- New data-provider test covers the overshoot cases, the unchanged absolute/relative cases, and `normalize()` on a scheme-only URI.
