### PR TITLE
Decode exactly the RFC 3986 unreserved set in Encoder

### DIFF
--- a/interfaces/Encoder.php
+++ b/interfaces/Encoder.php
@@ -59,7 +59,7 @@ final class Encoder
      *
      * @see https://www.rfc-editor.org/rfc/rfc3986.html#section-2.3
      */
-    private const REGEXP_UNRESERVED_CHARACTERS = ',%(2[DdEe]|3[0-9]|4[1-9A-Fa-f]|5[AaFf]|6[1-9A-Fa-f]|7[0-9A-Ea-e]),';
+    private const REGEXP_UNRESERVED_CHARACTERS = ',%(2[DdEe]|3[0-9]|4[1-9A-Fa-f]|5[0-9AaFf]|6[1-9A-Fa-f]|7[0-9AaEe]),';
 
     /**
      * Tell whether the user component is correctly encoded.

--- a/interfaces/EncoderTest.php
+++ b/interfaces/EncoderTest.php
@@ -167,4 +167,92 @@ final class EncoderTest extends TestCase
             'expected' => false,
         ];
     }
+
+    /**
+     * RFC 3986 §2.3 unreserved = ALPHA / DIGIT / "-" / "." / "_" / "~".
+     */
+    private static function isUnreserved(int $byte): bool
+    {
+        return ($byte >= 0x41 && $byte <= 0x5A)          // A-Z
+            || ($byte >= 0x61 && $byte <= 0x7A)          // a-z
+            || ($byte >= 0x30 && $byte <= 0x39)          // 0-9
+            || in_array($byte, [0x2D, 0x2E, 0x5F, 0x7E], true); // - . _ ~
+    }
+
+    #[Test]
+    public function it_decodes_every_unreserved_triplet_and_leaves_the_rest_encoded(): void
+    {
+        $underDecoded = [];
+        $overDecoded = [];
+        for ($byte = 0x00; $byte <= 0xFF; $byte++) {
+            $triplet = sprintf('%%%02X', $byte);
+            $isDecoded = Encoder::decodeUnreservedCharacters($triplet) !== $triplet;
+            match (true) {
+                self::isUnreserved($byte) && !$isDecoded => $underDecoded[] = $triplet,
+                !self::isUnreserved($byte) && $isDecoded => $overDecoded[] = $triplet,
+                default => null,
+            };
+        }
+
+        self::assertSame([], $underDecoded, 'unreserved characters were left percent-encoded');
+        self::assertSame([], $overDecoded, 'non unreserved characters were wrongly decoded');
+    }
+
+    #[Test]
+    #[DataProvider('provideUnreservedUserInfo')]
+    public function it_decodes_the_unreserved_set_in_user_and_password(string $encoded, string $expected): void
+    {
+        self::assertSame($expected, Encoder::normalizeUser($encoded));
+        self::assertSame($expected, Encoder::normalizePassword($encoded));
+    }
+
+    public static function provideUnreservedUserInfo(): iterable
+    {
+        yield 'uppercase letters P to Y were previously left encoded' => [
+            'encoded' => '%50%51%52%53%54%55%56%57%58%59',
+            'expected' => 'PQRSTUVWXY',
+        ];
+
+        yield 'boundary letters O, P and Z all decode' => [
+            'encoded' => '%4F%50%5A',
+            'expected' => 'OPZ',
+        ];
+
+        yield 'lowercase hex digits decode to the same character' => [
+            'encoded' => '%5a%59',
+            'expected' => 'ZY',
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('provideNonUnreserved')]
+    public function it_keeps_non_unreserved_characters_percent_encoded(string $encoded): void
+    {
+        self::assertSame($encoded, Encoder::decodeUnreservedCharacters($encoded));
+    }
+
+    public static function provideNonUnreserved(): iterable
+    {
+        yield 'curly braces and vertical bar were previously over-decoded' => ['encoded' => '%7B%7C%7D'];
+        yield 'brackets, backslash and caret stay encoded' => ['encoded' => '%5B%5C%5D%5E'];
+        yield 'grave accent stays encoded' => ['encoded' => '%60'];
+    }
+
+    #[Test]
+    public function it_normalizes_equivalent_userinfo_encodings_to_the_same_uri(): void
+    {
+        $normalized = (string) Uri::new('https://%50%51@ex.com/')->normalize();
+
+        self::assertSame('https://PQ@ex.com/', $normalized);
+        self::assertSame((string) Uri::new('https://PQ@ex.com/')->normalize(), $normalized);
+    }
+
+    #[Test]
+    public function it_decodes_the_unreserved_set_idempotently(): void
+    {
+        $once = Encoder::decodeUnreservedCharacters('%50%51%7B%7E');
+
+        self::assertSame('PQ%7B~', $once);
+        self::assertSame($once, Encoder::decodeUnreservedCharacters($once));
+    }
 }


### PR DESCRIPTION
## Summary

`Encoder::decodeUnreservedCharacters()` decides which `%XX` triplets to decode from a single hand-written range regex (`REGEXP_UNRESERVED_CHARACTERS`). Over the printable ASCII range it is wrong in **two opposite directions**:

- **Under-decodes:** `5[AaFf]` only matches `%5A`(Z) and `%5F`(_), so `%50`–`%59` — the unreserved letters **P Q R S T U V W X Y** — are never decoded.
- **Over-decodes:** `7[0-9A-Ea-e]` matches `%7B`–`%7D`, decoding **`{` `|` `}`**, which are not in the RFC 3986 [§2.3](https://www.rfc-editor.org/rfc/rfc3986#section-2.3) unreserved set.

Both errors come from the same ad-hoc range, so the fix narrows the character class to *exactly* the unreserved set (`ALPHA / DIGIT / "-" / "." / "_" / "~"`): `5[AaFf]` → `5[0-9AaFf]` adds P–Y, `7[0-9A-Ea-e]` → `7[0-9AaEe]` drops `{|}`.

## Impact

The user/password normalizers build on this, so equivalent encodings normalize differently:

```php
Encoder::normalizeUser('%50%51%52');                       // '%50%51%52', RFC wants 'PQR'
Encoder::decodeUnreservedCharacters('%7B');                // '{',        RFC wants '%7B'
(string) Uri::new('https://%50%51@ex.com/')->normalize();  // 'https://%50%51@ex.com/', not '…/PQ@…'
```

## Verification

A census over the full `0x00`–`0xFF` percent-encoded space against the literal RFC §2.3 unreserved definition: **before = 10 under-decodes + 3 over-decodes, after = 0 + 0**. That census ships as a test, alongside the userinfo/idempotence/hex-case cases. Percent-decoding stays case-insensitive on the hex digits (`%5a` == `%5A`).

Scope is limited to the userinfo path; `decodePath`/`decodeQuery`/`decodeFragment` use a different, correct decode-then-re-encode mechanism and are untouched. `interfaces/EncoderTest` goes 20 → 29 green; the rest of the suite is unchanged.
