### PR TITLE
Fix multibyte characters being split by the URI Template prefix modifier

### DIFF
--- a/uri/UriTemplate/Operator.php
+++ b/uri/UriTemplate/Operator.php
@@ -19,10 +19,10 @@ use Stringable;
 
 use function implode;
 use function is_array;
+use function mb_substr;
 use function preg_match;
 use function rawurlencode;
 use function str_contains;
-use function substr;
 
 /**
  * Processing behavior according to the expression type operator.
@@ -156,7 +156,9 @@ enum Operator: string
         }
 
         if (':' === $varSpec->modifier) {
-            $value = substr($value, 0, $varSpec->position);
+            // RFC 6570 section 2.4.1: the prefix length counts characters, not octets,
+            // so truncating has to be multibyte aware.
+            $value = mb_substr($value, 0, $varSpec->position, 'UTF-8');
         }
 
         return [$this->decode($value), $this->isNamed()];

--- a/uri/UriTemplateTest.php
+++ b/uri/UriTemplateTest.php
@@ -261,6 +261,20 @@ final class UriTemplateTest extends TestCase
         self::assertSame($expectedUri, $uriTemplate->expandToUrlOrFail($variables)->toAsciiString());
     }
 
+    public function testPrefixModifierTruncatesByCharacterNotByte(): void
+    {
+        // RFC 6570 section 2.4.1: the prefix counts characters, so a multibyte
+        // character must never be split. The euro sign and the G-clef are 3 and 4
+        // bytes but one character each.
+        $uriTemplate = new UriTemplate('{?currency:1}{clef:1}');
+        $variables = [
+            'currency' => "\u{20AC}uro",
+            'clef' => "\u{1D11E}stave",
+        ];
+
+        self::assertSame('?currency=%E2%82%AC%F0%9D%84%9E', $uriTemplate->expand($variables)->toString());
+    }
+
     public function testDisallowNestedArrayExpansion(): void
     {
         $template = 'http://example.com{?query,data*,foo*}';


### PR DESCRIPTION

## Problem

Problem
-------

`UriTemplate::expand()` corrupts any variable value that starts with a
multibyte UTF-8 character when a prefix modifier (`{var:N}`) is used.
Instead of taking the first N characters, it takes the first N bytes,
which can split a multibyte character in half and produce an invalid,
undecodable percent-encoded fragment.

Reproduction on a clean checkout:

    $ php -r '
    require "vendor/autoload.php";
    use League\Uri\UriTemplate;
    $template = new UriTemplate("{?currency:1}");
    echo $template->expand(["currency" => "\u{20AC}uro"]);
    '

    ?currency=%E2

The euro sign (U+20AC) is a single character but 3 bytes in UTF-8
(E2 82 AC). A one-character prefix should keep the whole character
and print `?currency=%E2%82%AC`; instead only the first byte survives,
producing a percent-encoded sequence that is not valid UTF-8 once
decoded.

This is also caught by the RFC 6570 conformance suite the project
already vendors (`uri-templates/uritemplate-test`), specifically the
"Prefix Modifiers with Multibyte Characters" additional examples,
which fail on a clean checkout for the same reason.

Root cause
----------

`Operator::inject()` (uri/UriTemplate/Operator.php:159) applies the
`:N` prefix modifier with the byte-oriented `substr()`:

    if (':' === $varSpec->modifier) {
        $value = substr($value, 0, $varSpec->position);
    }

RFC 6570 Section 2.4.1 defines the prefix length as a count of
characters, not octets: "the length is calculated in characters,
where each Unicode character ... counts as one, regardless of the
number of octets". A byte-oriented `substr()` violates this whenever
the value contains a non-ASCII character within the first N
characters.

Fix
---

Replace the byte-oriented `substr()` with the multibyte-aware
`mb_substr()`, explicit about the UTF-8 encoding so the truncation
does not depend on the host application's `mb_internal_encoding()`
setting. `ext-mbstring` is already a hard `require` of this package
(composer.json), so no new dependency is introduced.

Verification
------------

    $ composer install
    $ vendor/bin/phpunit --no-coverage
    Tests: 2882, Assertions: 4698, Errors: 32, Failures: 5.

The 32 errors and 5 failures are pre-existing on a clean checkout and
unrelated to this change:

  - 32 errors: `Call to undefined function gmp_pow()` /
    `intl` extension not available in this sandbox (no `ext-gmp` or
    `ext-intl`, and no root access to install them here). These are
    IPv4/IDN tests unrelated to UriTemplate.
  - 5 failures: 4 "Failure Tests" data sets in `TemplateTest` and one
    "Literal Encoding" case (`café/{var}` not percent-encoding the
    literal `café` portion of the template). This is a distinct,
    pre-existing gap in how literal template text is encoded, not
    touched by this fix; flagging it separately below rather than
    folding an unrelated change into this PR.

Before this fix, the same command reports 11 failures instead of 5:
the 6 multibyte prefix-modifier cases in
`uri/UriTemplate/TemplateTest.php` (Additional Examples 7) plus the
new regression test added below.

A new test, `UriTemplateTest::testPrefixModifierTruncatesByCharacterNotByte`,
was added (not modifying any existing test). Reverting only the fix
in `Operator.php` while keeping this test reproduces the bug:

    1) League\Uri\UriTemplateTest::testPrefixModifierTruncatesByCharacterNotByte
    Failed asserting that two strings are identical.
    --- Expected
    +++ Actual
    @@ @@
    -'?currency=%E2%82%AC%F0%9D%84%9E'
    +'?currency=%E2%F0'

    $ composer phpstan
    (2 pre-existing errors, present identically on a clean checkout in
    this sandbox, both about `#[Deprecated]` attribute resolution and
    unrelated to this change)

    $ composer phpcs
    Found 0 of 145 files that can be fixed.

Flags for the account owner
----------------------------

- No CLA/DCO requirement found in CONTRIBUTING.md.
- Also note: `thephpleague/uri` is a read-only sub-split; this PR
  targets `thephpleague/uri-src` as instructed by that repo's own
  auto-close bot.
- Separate, pre-existing issue noticed while investigating (not fixed
  here, flagging for awareness): `Template::expandAll()`
  (uri/UriTemplate/Template.php) does a plain `str_replace()` of each
  `{...}` expression into the original template string, so literal
  template text is never percent-encoded. The official RFC 6570
  extended test suite's "café/{var}" case expects `caf%C3%A9/value`
  but gets `café/value`. This is a different code path and a
  different kind of fix (deciding how literal text should be
  encoded), so it is intentionally left out of this PR to keep it
  minimal.
- This sandbox has neither `ext-gmp` nor `ext-intl`/a working IDN
  polyfill installed by default; I temporarily added
  `symfony/polyfill-intl-idn` (and its transitive polyfills) to
  `composer.json` locally to get the suite collecting tests at all,
  then reverted that composer.json change before finalizing this
  diff. It is not part of this PR.
