### PR TITLE
Percent encode the URI template literals as per RFC 6570 section 3.1

### DIFF
--- a/docs/uri/7.0/uri-template.md
+++ b/docs/uri/7.0/uri-template.md
@@ -85,6 +85,31 @@ echo $uriTemplate->expandOrFail($params);
 <p class="message-notice"><code>expandToUriOrFail()</code> and <code>expandToUrlOrFail()</code> are available since
 version <code>7.6.0</code></p>
 
+### Literal Expansion
+
+The characters located outside of the template expressions are literals. As per
+[RFC6570 section 3.1](https://www.rfc-editor.org/rfc/rfc6570#section-3.1) a literal character is
+copied as is when it is allowed anywhere in the URI syntax, in other words when it belongs to the
+`unreserved / reserved / pct-encoded` set. Any other character is percent encoded using its UTF-8
+octets.
+
+~~~php
+$uriTemplate = new UriTemplate('https://example.com/café/{hotel}');
+
+echo $uriTemplate->expand(['hotel' => 'Rest & Relax']), PHP_EOL;
+// display https://example.com/caf%C3%A9/Rest%20%26%20Relax
+~~~
+
+Percent encoded triplets already present in the template are left untouched, they are never
+encoded a second time.
+
+~~~php
+$uriTemplate = new UriTemplate('https://example.com/caf%C3%A9/{hotel}');
+
+echo $uriTemplate->expand(['hotel' => 'Rest & Relax']), PHP_EOL;
+// display https://example.com/caf%C3%A9/Rest%20%26%20Relax
+~~~
+
 ## Template Variables
 
 <p class="message-notice">For maximum interoperability you should make sure your variables are 

--- a/uri/UriTemplate/Template.php
+++ b/uri/UriTemplate/Template.php
@@ -20,14 +20,18 @@ use Stringable;
 
 use function array_filter;
 use function array_map;
-use function array_reduce;
 use function array_unique;
-use function preg_match_all;
+use function array_values;
+use function implode;
 use function preg_replace;
-use function str_replace;
+use function preg_replace_callback;
+use function preg_split;
+use function rawurlencode;
+use function str_starts_with;
 use function strpbrk;
 
-use const PREG_SET_ORDER;
+use const PREG_SPLIT_DELIM_CAPTURE;
+use const PREG_SPLIT_NO_EMPTY;
 
 /**
  * @internal The class exposes the internal representation of a Template and its usage
@@ -39,19 +43,36 @@ final class Template implements Stringable
      */
     private const REGEXP_EXPRESSION_DETECTOR = '/(?<expression>\{[^}]*})/x';
 
-    /** @var array<Expression> */
-    private readonly array $expressions;
+    /**
+     * Literal characters which must be percent encoded in the expanded
+     * template: everything outside "unreserved / reserved / pct-encoded", a
+     * "%" starting no triplet included.
+     *
+     * @link https://www.rfc-editor.org/rfc/rfc6570#section-3.1
+     */
+    private const REGEXP_LITERAL_TO_ENCODE = '/[^A-Za-z\d\-._~:\/?#\[\]@!$&\'()*+,;=%]+|%(?![A-Fa-f\d]{2})/';
+
+    /** @var array<string|Expression> */
+    private readonly array $parts;
     /** @var array<string> */
     public readonly array $variableNames;
 
-    private function __construct(public readonly string $value, Expression ...$expressions)
+    private function __construct(public readonly string $value, string|Expression ...$parts)
     {
-        $this->expressions = $expressions;
+        $this->parts = $parts;
+
+        $expressions = [];
+        foreach ($parts as $part) {
+            if ($part instanceof Expression) {
+                $expressions[$part->value] = $part;
+            }
+        }
+
         $this->variableNames = array_unique(
             array_merge(
                 ...array_map(
                     static fn (Expression $expression): array => $expression->variableNames,
-                    $expressions
+                    array_values($expressions)
                 )
             )
         );
@@ -72,17 +93,35 @@ final class Template implements Stringable
         $remainder = preg_replace(self::REGEXP_EXPRESSION_DETECTOR, '', $template);
         false === strpbrk($remainder, '{}') || throw new SyntaxError('The template "'.$template.'" contains invalid expressions.');
 
-        preg_match_all(self::REGEXP_EXPRESSION_DETECTOR, $template, $founds, PREG_SET_ORDER);
+        /** @var array<string> $segments */
+        $segments = preg_split(self::REGEXP_EXPRESSION_DETECTOR, $template, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
 
-        return new self($template, ...array_values(
-            array_reduce($founds, function (array $carry, array $found): array {
-                if (!isset($carry[$found['expression']])) {
-                    $carry[$found['expression']] = Expression::new($found['expression']);
-                }
+        $parts = [];
+        $expressions = [];
+        foreach ($segments as $segment) {
+            if (!str_starts_with($segment, '{')) {
+                $parts[] = self::encodeLiteral($segment);
+                continue;
+            }
 
-                return $carry;
-            }, [])
-        ));
+            $parts[] = $expressions[$segment] ??= Expression::new($segment);
+        }
+
+        return new self($template, ...$parts);
+    }
+
+    /**
+     * Percent encodes the template characters which are not allowed to be copied as-is into a URI.
+     *
+     * @link https://www.rfc-editor.org/rfc/rfc6570#section-3.1
+     */
+    private static function encodeLiteral(string $literal): string
+    {
+        return (string) preg_replace_callback(
+            self::REGEXP_LITERAL_TO_ENCODE,
+            static fn (array $matches): string => rawurlencode($matches[0]),
+            $literal
+        );
     }
 
     /**
@@ -116,11 +155,10 @@ final class Template implements Stringable
 
     private function expandAll(VariableBag $variables): string
     {
-        return array_reduce(
-            $this->expressions,
-            fn (string $uri, Expression $expr): string => str_replace($expr->value, $expr->expand($variables), $uri),
-            $this->value
-        );
+        return implode('', array_map(
+            static fn (string|Expression $part): string => $part instanceof Expression ? $part->expand($variables) : $part,
+            $this->parts
+        ));
     }
 
     public function __toString(): string

--- a/uri/UriTemplate/TemplateTest.php
+++ b/uri/UriTemplate/TemplateTest.php
@@ -174,6 +174,63 @@ final class TemplateTest extends TestCase
         ];
     }
 
+    #[DataProvider('providesLiteralEncoding')]
+    #[Test]
+    public function testItEncodesTheTemplateLiterals(string $notation, array $variables, string $expected): void
+    {
+        self::assertSame($expected, Template::new($notation)->expand($variables));
+    }
+
+    /**
+     * @see https://www.rfc-editor.org/rfc/rfc6570#section-3.1
+     */
+    public static function providesLiteralEncoding(): iterable
+    {
+        $variables = [
+            'var' => 'value',
+            'path' => '/foo/bar',
+            'hello' => 'Hello World!',
+        ];
+
+        return [
+            'a character disallowed in a URI is encoded as its UTF-8 octets' => [
+                'notation' => 'café/{var}',
+                'variables' => $variables,
+                'expected' => 'caf%C3%A9/value',
+            ],
+            'a percent encoded triplet is copied as is' => [
+                'notation' => 'x%20y/{var}',
+                'variables' => $variables,
+                'expected' => 'x%20y/value',
+            ],
+            'a percent encoded triplet is copied as is on both sides of an expression' => [
+                'notation' => 'x%20y{var}z%20w',
+                'variables' => $variables,
+                'expected' => 'x%20yvaluez%20w',
+            ],
+            'a space is encoded' => [
+                'notation' => 'a b/{var}',
+                'variables' => $variables,
+                'expected' => 'a%20b/value',
+            ],
+            'a percent sign which starts no triplet is encoded' => [
+                'notation' => '100%/{var}',
+                'variables' => $variables,
+                'expected' => '100%25/value',
+            ],
+            'reserved characters are copied as is' => [
+                'notation' => "/a[0]:b@c!d\$e&f'g(h)i*j+k,l;m=n?o#{var}",
+                'variables' => $variables,
+                'expected' => "/a[0]:b@c!d\$e&f'g(h)i*j+k,l;m=n?o#value",
+            ],
+            'the expanded expressions are never encoded twice' => [
+                'notation' => 'café{+path}{#hello}',
+                'variables' => $variables,
+                'expected' => 'caf%C3%A9/foo/bar#Hello%20World!',
+            ],
+        ];
+    }
+
     public function testExpandOrFailIfAtLeastOneVariableIsMissing(): void
     {
         $this->expectException(TemplateCanNotBeExpanded::class);


### PR DESCRIPTION

## Problem

| Q           | A      |
|-------------|--------|
| Package     | league/uri (uri-src monorepo) |
| Bug fix     | yes    |
| New Feature | no     |
| BC Break    | no (the behaviour only changes for templates whose literal part contains characters that are not valid in a URI) |
| Target      | master |

> Note on this description: it is written in pure ASCII, so the character U+00E9
> (LATIN SMALL LETTER E WITH ACUTE) is spelled `\u{E9}` below. The code and the tests use the raw
> UTF-8 character, exactly like the vendored compliance suite does.

## Problem

The literal text of a URI template, that is everything located outside of the `{...}`
expressions, is never percent encoded. A template carrying a character which is not allowed in a
URI is copied verbatim into the expansion result:

```php
use League\Uri\UriTemplate\Template;

Template::new("caf\u{E9}/{var}")->expand(['var' => 'value']);
// actual:   "caf\u{E9}/value"
// expected: "caf%C3%A9/value"
```

The official URI Template compliance suite (`uri-templates/uritemplate-test`, already vendored by
this repository and already wired into `TemplateTest::testItCompliesWithUriTemplatesExpansionTests`)
covers this in `extended-tests.json`, section *Additional Examples 8: Literal Encoding*. On master
it reports:

## What the RFC says

RFC 6570, section 3.1 "Literal Expansion":

> If the literal character is allowed anywhere in the URI syntax (unreserved / reserved /
> pct-encoded ), then it is copied directly to the result string. Otherwise, the pct-encoded
> equivalent of the literal character is copied to the result string by first encoding the
> character as its sequence of octets in UTF-8 and then encoding each such octet as a pct-encoded
> triplet.

Section 2.1 "Literals" states the same requirement from the parsing side:

> The characters outside of expressions in a URI Template string are intended to be copied
> literally to the URI reference if the character is allowed in a URI (reserved / unreserved /
> pct-encoded) or, if not allowed, copied to the URI reference as the sequence of pct-encoded
> triplets corresponding to that character's encoding in UTF-8 [RFC3629].

## Root cause

`uri/UriTemplate/Template.php`, `Template::expandAll()`, line 117 on master:

```php
private function expandAll(VariableBag $variables): string
{
    return array_reduce(
        $this->expressions,
        fn (string $uri, Expression $expr): string => str_replace($expr->value, $expr->expand($variables), $uri),
        $this->value
    );
}
```

The expansion starts from `$this->value`, the raw template string, and swaps every expression
notation for its expanded value with `str_replace()`. Whatever surrounds the expressions is
carried over untouched, so the literal part never goes through any encoding step. `Template` only
kept the deduplicated list of `Expression` objects, so by the time `expandAll()` runs, the
information about which slice of the string is a literal is already lost.

## The fix

Encoding the literals cannot be done on the assembled string: `Operator::inject()` already encodes
the expansion results, so a post-pass over the whole result would turn `%C3%A9` into `%25C3%25A9`,
and it would also encode the `#` produced by the fragment operator. The information about what is
a literal and what is an expansion result therefore has to be kept, rather than recovered
afterwards.

`Template::new()` now splits the template with `preg_split()` and `PREG_SPLIT_DELIM_CAPTURE`, using
the very same `REGEXP_EXPRESSION_DETECTOR` pattern that already served to detect the expressions.
The resulting ordered list of parts is stored on the instance: expression segments become
`Expression` objects (still parsed once per distinct notation), literal segments are percent
encoded once, at construction time. `expandAll()` then concatenates the parts, expanding the
`Expression` ones. Each part is produced by exactly one code path, so an expansion result is never
handed to the literal encoder and vice versa.

The literal encoder implements section 3.1 verbatim:

```php
private const REGEXP_LITERAL_TO_ENCODE = '/[^A-Za-z\d\-._~:\/?#\[\]@!$&\'()*+,;=%]+|%(?![A-Fa-f\d]{2})/';
```

The negated character class is the `unreserved / reserved` set of RFC 3986, so only characters that
are not allowed anywhere in the URI syntax are matched. `%` is deliberately kept out of that class
so that a valid `pct-encoded` triplet is copied directly, as the RFC requires; the second branch
catches a `%` that starts no triplet and encodes it to `%25`. Matched runs are passed to
`rawurlencode()`, which produces exactly the UTF-8 octet triplets the RFC asks for.

What is intentionally *not* changed:

- `Template::$value` and `Template::__toString()` still return the original template string.
- `Template::$variableNames` keeps its previous content and ordering, the deduplication by
  expression notation is preserved.
- The `+` and `#` operators keep their own reserved expansion rules, untouched, because their
  output is never re-processed by the literal encoder.
- Percent encoded triplets already present in the template are left as they are, hexadecimal case
  included, since section 3.1 asks for them to be "copied directly".

## Compliance suite, before and after

`vendor/bin/phpunit --no-coverage --filter testItCompliesWithUriTemplatesExpansionTests uri/UriTemplate/TemplateTest.php`

| | passing | failing |
|---|---|---|
| before | 142 / 153 | 11 |
| after  | 143 / 153 | 10 |

The single case that flips is *Additional Examples 8: Literal Encoding # 1*. The other two cases of
that section, `x%20y/{var}` and `x%20y{var}z%20w`, were already passing and still pass; they are
the ones guarding against double encoding.

The 10 remaining failures are pre-existing and out of the scope of this pull request: 4 come from
`negative-tests.json` (varspec prefixes such as `{var:0}` and `{var:01}` are not rejected) and 6
from *Additional Examples 7: Prefix Modifiers with Multibyte Characters* (the `:` prefix modifier
counts bytes instead of characters). Neither is touched by this patch.

## Tests

`TemplateTest::testItEncodesTheTemplateLiterals` is added with 7 cases: a non-ASCII literal, a
space, a `%` that starts no triplet, reserved characters that must survive untouched, percent
encoded triplets on both sides of an expression, and one case combining a non-ASCII literal with a
`{+var}` and a `{#var}` expansion to pin that expansion results are never encoded a second time.

4 of those 7 cases fail on master. Reverting only the body of `Template::encodeLiteral()` to
`return $literal;`, and keeping everything else in place, makes exactly those 4 fail again, with
`caf%C3%A9/value` vs `caf\u{E9}/value`, `a%20b/value` vs `a b/value`, `100%25/value` vs
`100%/value`, and `caf%C3%A9/foo/bar#Hello%20World!` vs `caf\u{E9}/foo/bar#Hello%20World!`.
